### PR TITLE
fix: remove a deprecated corset argument -P from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ ZKEVM_MODULES := ${ALU} \
          ${OOB} \
 
 define.go: ${ZKEVM_MODULES}
-	${CORSET} wizard-iop -vv -P define -o $@ ${ZKEVM_MODULES}
+	${CORSET} wizard-iop -vv define -o $@ ${ZKEVM_MODULES}
 
 zkevm.bin: ${ZKEVM_MODULES}
 	${CORSET} compile -vv -o $@ ${ZKEVM_MODULES}


### PR DESCRIPTION
this PR removes a deprecated corset argument -P from the Makefile:

problem: 
when `make define.go` 

```
gusiri@gusiri:~/zkevm-monorepo/constraints$ make define.go
corset wizard-iop -vv -P define -o define.go alu/add/columns.lisp alu/add/constraints.lisp alu/ext/columns.lisp alu/ext/constraints.lisp alu/mod/columns.lisp alu/mod/constants.lisp alu/mod/constraints.lisp alu/mul/columns.lisp alu/mul/constraints.lisp alu/mul/helpers.lisp bin    blake2fmodexpdata blockdata blockhash constants/constants.lisp ecdata euc library/rlp_constraints_pattern.lisp logdata loginfo mmu mmio/columns.lisp  mxp rlpaddr rlptxn rlptxrcpt                    rom romlex shakiradata shf stp reftables/bin_reftable.lisp reftables/shf_reftable.lisp reftables/inst_decoder.lisp trm txndata wcp
error: unexpected argument '-P' found

  tip: to pass '-P' as a value, use '-- -P'

Usage: corset wizard-iop [OPTIONS] [SOURCE]...

For more information, try '--help'.
make: *** [Makefile:130: define.go] Error 2

```

The latest corset (v9.7.10) --help shows that it does not have -P argument anymore.
```
Options:
  -v, --verbose...                           Increase logging verbosity
  -q, --quiet...                             Decrease logging verbosity
  -e...                                      perform various levels of expansion
      --auto-constraints <AUTO_CONSTRAINTS>  [possible values: sorts, nhood]
      --debug                                Compile code in debug mode
  -t, --threads <THREADS>                    number of threads to use [default: 1]
  -N, --native                               execute computations in target Galois field
      --no-stdlib                            
  -h, --help                                 Print help
  -V, --version                              Print version

```

