### PR TITLE
Fix build rule for `define.go`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ ZKEVM_MODULES := ${ALU} \
 #        ${HUB} \
 
 define.go: ${ZKEVM_MODULES}
-	${CORSET} wizard-iop -vv define -o $@ ${ZKEVM_MODULES}
+	${CORSET} wizard-iop -vv -o $@ ${ZKEVM_MODULES}
 
 zkevm.bin: ${ZKEVM_MODULES}
 	${CORSET} compile -vv -o $@ ${ZKEVM_MODULES}


### PR DESCRIPTION
This fixes the build rule for `define.go`.  There was a spurious command-line option (`define`) which was removed.