### PR TITLE
Fix `loginfo` guards

### DIFF
--- a/loginfo/constraints.lisp
+++ b/loginfo/constraints.lisp
@@ -97,13 +97,13 @@
 ;;                           ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun (is-log0-to-log4)
-  (force-bool (+ (for k [0 : 4] [IS_LOG_X k]))))
+  (force-bool (reduce + (for k [0 : 4] [IS_LOG_X k]))))
 
 (defun (is-log1-to-log4)
-  (force-bool (+ (for k [1 : 4] [IS_LOG_X k]))))
+  (force-bool (reduce + (for k [1 : 4] [IS_LOG_X k]))))
 
 (defun (is-log2-to-log4)
-  (force-bool (+ (for k [2 : 4] [IS_LOG_X k]))))
+  (force-bool (reduce + (for k [2 : 4] [IS_LOG_X k]))))
 
 (defun (is-log3-to-log4)
   (force-bool (+ [IS_LOG_X 3] [IS_LOG_X 4])))


### PR DESCRIPTION
This makes a small number of changes to some `:guard`s used in the `loginfo` module.  Specifically, the guards were incorrectly specified without the `reduce` keyword.