### PR TITLE
fix(exp): use CT_MAX_CMPTN_MODEXP_LOG

### DIFF
--- a/exp/constraints.lisp
+++ b/exp/constraints.lisp
@@ -208,7 +208,7 @@
                                      (eq! MSB TRIM_BYTE)))))
 
 (defconstraint most-significant-byte-end (:perspective computation :guard IS_MODEXP_LOG)
-  (if-eq CT 15
+  (if-eq CT CT_MAX_CMPTN_MODEXP_LOG
          (if-zero TANZB_ACC
                   (vanishes! MSB))))
 

--- a/exp/constraints.lisp
+++ b/exp/constraints.lisp
@@ -208,7 +208,7 @@
                                      (eq! MSB TRIM_BYTE)))))
 
 (defconstraint most-significant-byte-end (:perspective computation :guard IS_MODEXP_LOG)
-  (if-eq CT CT_MAX_CMPTN_MODEXP_LOG
+  (if-eq CT CT_MAX
          (if-zero TANZB_ACC
                   (vanishes! MSB))))
 


### PR DESCRIPTION
https://veridise.notion.site/Magic-number-should-be-replaced-with-CT_MAX_CMPTN_MODEXP_LOG-constant-182404a228cb40f4943b784f0dca57db