### PR TITLE
Add missing _NEW's to TX_INIT and TX_SKIP sections

### DIFF
--- a/hub/constraints/tx_init/constraints.lisp
+++ b/hub/constraints/tx_init/constraints.lisp
@@ -124,9 +124,9 @@
                                 (vanishes!      (shift account/CODE_SIZE              tx-init---row-offset---recipient-account-row))
                                 ;; updated code
                                 (vanishes!      (shift account/HAS_CODE_NEW           tx-init---row-offset---recipient-account-row))
-                                (debug     (eq! (shift account/CODE_HASH_HI           tx-init---row-offset---recipient-account-row) EMPTY_KECCAK_HI))
-                                (debug     (eq! (shift account/CODE_HASH_LO           tx-init---row-offset---recipient-account-row) EMPTY_KECCAK_LO))
-                                (eq!            (shift account/CODE_SIZE              tx-init---row-offset---recipient-account-row)
+                                (debug     (eq! (shift account/CODE_HASH_HI_NEW       tx-init---row-offset---recipient-account-row) EMPTY_KECCAK_HI))
+                                (debug     (eq! (shift account/CODE_HASH_LO_NEW       tx-init---row-offset---recipient-account-row) EMPTY_KECCAK_LO))
+                                (eq!            (shift account/CODE_SIZE_NEW          tx-init---row-offset---recipient-account-row)
                                                 (shift transaction/INIT_CODE_SIZE     tx-init---row-offset---transaction-row)))))
 
 (defconstraint   tx-initialization---recipient-account-row---deployment-transaction---deployment-number-and-status       (:guard (tx-init---standard-precondition))

--- a/hub/constraints/tx_skip/constraints.lisp
+++ b/hub/constraints/tx_skip/constraints.lisp
@@ -100,11 +100,11 @@
                                  (vanishes!         (shift account/CODE_SIZE       tx-skip---row-offset---recipient-account))
                                  ;; updated code
                                  (vanishes!         (shift account/HAS_CODE_NEW       tx-skip---row-offset---recipient-account))
-                                 (debug    (eq!     (shift account/CODE_HASH_HI       tx-skip---row-offset---recipient-account)    EMPTY_KECCAK_HI))
-                                 (debug    (eq!     (shift account/CODE_HASH_LO       tx-skip---row-offset---recipient-account)    EMPTY_KECCAK_LO))
-                                 (eq!               (shift account/CODE_SIZE          tx-skip---row-offset---recipient-account)
+                                 (debug    (eq!     (shift account/CODE_HASH_HI_NEW   tx-skip---row-offset---recipient-account)    EMPTY_KECCAK_HI))
+                                 (debug    (eq!     (shift account/CODE_HASH_LO_NEW   tx-skip---row-offset---recipient-account)    EMPTY_KECCAK_LO))
+                                 (eq!               (shift account/CODE_SIZE_NEW      tx-skip---row-offset---recipient-account)
                                                     (shift transaction/INIT_CODE_SIZE tx-skip---row-offset---transaction-row))
-                                 (debug (vanishes!  (shift account/CODE_SIZE          tx-skip---row-offset---recipient-account))))))
+                                 (debug (vanishes!  (shift account/CODE_SIZE_NEW      tx-skip---row-offset---recipient-account))))))
 
 (defconstraint tx-skip---recipient-account-row---trivial-deployments---deployment-status-and-number (:guard (tx-skip---precondition))
                (if-not-zero    (tx-skip---is-deployment)


### PR DESCRIPTION
This PR fixes typos from #430.