### PR TITLE
Typo and bug fixes for the `ACC` instruction family

### DIFF
--- a/hub/constraints/instruction-handling/acc.lisp
+++ b/hub/constraints/instruction-handling/acc.lisp
@@ -23,42 +23,45 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
+;; ROFF ≡ ROW_OFFSET
+;; ACC  ≡ ACCOUNT_FAMILY
 (defconst
-  ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW            1
-  ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW    2
+  ROFF_ACC___CONTEXT_ROW            1
+  ROFF_ACC___ACCOUNT_READING_ROW    2
 
-  ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW      1
-  ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    2
+  ROFF_ACC___ACCOUNT_DOING_ROW      1
+  ROFF_ACC___ACCOUNT_UNDOING_ROW    2
   )
 
+
+(defun (account-instruction---raw-address-hi)           [ stack/STACK_ITEM_VALUE_HI 1 ])
+(defun (account-instruction---raw-address-lo)           [ stack/STACK_ITEM_VALUE_LO 1 ])
+
+(defun (account-instruction---result-hi)                [ stack/STACK_ITEM_VALUE_HI 4 ])
+(defun (account-instruction---result-lo)                [ stack/STACK_ITEM_VALUE_LO 4 ])
 
 (defun (account-instruction---is-BALANCE)               [ stack/DEC_FLAG 1 ] )
 (defun (account-instruction---is-EXTCODESIZE)           [ stack/DEC_FLAG 2 ] )
 (defun (account-instruction---is-EXTCODEHASH)           [ stack/DEC_FLAG 3 ] )
-(defun (account-instruction---is-CODESIZE)              [ stack/DEC_FLAG 4 ] )
-(defun (account-instruction---raw-address-hi)           [ stack/STACK_ITEM_VALUE_HI 1 ])
-(defun (account-instruction---raw-address-lo)           [ stack/STACK_ITEM_VALUE_LO 1 ])
-(defun (account-instruction---result-hi)                [ stack/STACK_ITEM_VALUE_HI 4 ])
-(defun (account-instruction---result-lo)                [ stack/STACK_ITEM_VALUE_LO 4 ]) ;; ""
-
+(defun (account-instruction---is-CODESIZE)              [ stack/DEC_FLAG 4 ] ) ;; ""
 (defun (account-instruction---is-SELFBALANCE)           (-    1
                                                               (account-instruction---is-BALANCE)
                                                               (account-instruction---is-EXTCODESIZE)
                                                               (account-instruction---is-EXTCODEHASH)
                                                               (account-instruction---is-CODESIZE)))
 
-(defun (account-instruction---touches-foreign-account)  (+ (account-instruction---is-BALANCE)
-                                                           (account-instruction---is-EXTCODESIZE)
-                                                           (account-instruction---is-EXTCODEHASH)))
-(defun (account-instruction---touches-current-account)  (+ (account-instruction---is-CODESIZE)
-                                                           (account-instruction---is-SELFBALANCE)))
+(defun (account-instruction---touches-foreign-account)  (+    (account-instruction---is-BALANCE)
+                                                              (account-instruction---is-EXTCODESIZE)
+                                                              (account-instruction---is-EXTCODEHASH)))
 
-(defun (account-instruction---no-trimming)              (- stack/ACC_FLAG (account-instruction---touches-foreign-account)))
-(defun (account-instruction---account-address-hi)       (shift   context/ACCOUNT_ADDRESS_HI     ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW))
-(defun (account-instruction---account-address-lo)       (shift   context/ACCOUNT_ADDRESS_LO     ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW))
-(defun (account-instruction---byte-code-address-hi)     (shift   context/BYTE_CODE_ADDRESS_HI   ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW))
-(defun (account-instruction---byte-code-address-lo)     (shift   context/BYTE_CODE_ADDRESS_LO   ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW))
-(defun (account-instruction---foreign-address-warmth)   (shift   account/WARMTH                 ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW))
+(defun (account-instruction---touches-current-account)  (+    (account-instruction---is-CODESIZE)
+                                                              (account-instruction---is-SELFBALANCE)))
+
+(defun (account-instruction---account-address-hi)       (shift   context/ACCOUNT_ADDRESS_HI     ROFF_ACC___CONTEXT_ROW))
+(defun (account-instruction---account-address-lo)       (shift   context/ACCOUNT_ADDRESS_LO     ROFF_ACC___CONTEXT_ROW))
+(defun (account-instruction---byte-code-address-hi)     (shift   context/BYTE_CODE_ADDRESS_HI   ROFF_ACC___CONTEXT_ROW))
+(defun (account-instruction---byte-code-address-lo)     (shift   context/BYTE_CODE_ADDRESS_LO   ROFF_ACC___CONTEXT_ROW))
+(defun (account-instruction---foreign-address-warmth)   (shift   account/WARMTH                 ROFF_ACC___ACCOUNT_DOING_ROW))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -79,8 +82,8 @@
                  (:guard (account-instruction---standard-hypothesis))
                  ;;
                  (begin
-                   (if-not-zero (account-instruction---touches-foreign-account) (stack-pattern-1-1))
-                   (if-not-zero (account-instruction---no-trimming)             (stack-pattern-0-1))))
+                   (if-not-zero    (account-instruction---touches-foreign-account)    (stack-pattern-1-1))
+                   (if-not-zero    (account-instruction---touches-current-account)    (stack-pattern-0-1))))
 
 (defconstraint   account-instruction---setting-allowable-exceptions
                  (:guard (account-instruction---standard-hypothesis))
@@ -92,7 +95,7 @@
                  ;;
                  (begin
                    (if-not-zero    (account-instruction---touches-foreign-account)    (eq! NSR (+ 1 CONTEXT_WILL_REVERT CMC)))
-                   (if-not-zero    (account-instruction---no-trimming)                (eq! NSR (+ 1 (- 1 CMC))))
+                   (if-not-zero    (account-instruction---touches-current-account)    (eq! NSR (+ 1 (- 1 CMC))))
                    (debug          (eq! XAHOY CMC))
                    (debug          (eq! XAHOY stack/OOGX))))
 
@@ -103,19 +106,19 @@
                    (if-not-zero (account-instruction---touches-foreign-account)
                                 (if-zero CONTEXT_WILL_REVERT
                                          (eq! NSR
-                                              (+        (shift PEEK_AT_ACCOUNT        ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                              (+        (shift PEEK_AT_ACCOUNT        ROFF_ACC___ACCOUNT_DOING_ROW)
                                                         (* CMC (shift PEEK_AT_CONTEXT 2))))
                                          (eq! NSR
-                                              (+        (shift PEEK_AT_ACCOUNT        ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                                        (shift PEEK_AT_ACCOUNT        ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW)
+                                              (+        (shift PEEK_AT_ACCOUNT        ROFF_ACC___ACCOUNT_DOING_ROW)
+                                                        (shift PEEK_AT_ACCOUNT        ROFF_ACC___ACCOUNT_UNDOING_ROW)
                                                         (* CMC (shift PEEK_AT_CONTEXT 3))))))
-                   (if-not-zero (account-instruction---no-trimming)
+                   (if-not-zero (account-instruction---touches-current-account)
                                 (if-zero XAHOY
                                          (eq! NSR
-                                              (+ (shift    PEEK_AT_CONTEXT    ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW)
-                                                 (shift    PEEK_AT_ACCOUNT    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)))
+                                              (+ (shift    PEEK_AT_CONTEXT    ROFF_ACC___CONTEXT_ROW)
+                                                 (shift    PEEK_AT_ACCOUNT    ROFF_ACC___ACCOUNT_READING_ROW)))
                                          (eq! NSR
-                                              (shift PEEK_AT_CONTEXT    1))))))
+                                              (shift       PEEK_AT_CONTEXT    ROFF_ACC___CONTEXT_ROW))))))
 
 (defconstraint   account-instruction---setting-gas-cost
                  (:guard (account-instruction---standard-hypothesis))
@@ -125,7 +128,7 @@
                                 (eq! GAS_COST
                                      (+ (*      (account-instruction---foreign-address-warmth)  GAS_CONST_G_WARM_ACCESS)
                                         (* (- 1 (account-instruction---foreign-address-warmth)) GAS_CONST_G_COLD_ACCOUNT_ACCESS))))
-                   (if-not-zero (account-instruction---no-trimming)
+                   (if-not-zero (account-instruction---touches-current-account)
                                 (eq! GAS_COST
                                      stack/STATIC_GAS))))
 
@@ -138,13 +141,13 @@
                                   (eq! account/ROMLEX_FLAG            1)
                                   (eq! account/TRM_RAW_ADDRESS_HI    (account-instruction---raw-address-hi))
                                   (eq! account/ADDRESS_LO            (account-instruction---raw-address-lo))
-                                  (account-same-balance                         ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                  (account-same-nonce                           ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                  (account-same-code                            ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                  (account-same-deployment-number-and-status    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                  (account-turn-on-warmth                       ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                  (account-same-marked-for-selfdestruct         ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                  (DOM-SUB-stamps---standard                    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW 0)))))
+                                  (account-same-balance                         ROFF_ACC___ACCOUNT_DOING_ROW)
+                                  (account-same-nonce                           ROFF_ACC___ACCOUNT_DOING_ROW)
+                                  (account-same-code                            ROFF_ACC___ACCOUNT_DOING_ROW)
+                                  (account-same-deployment-number-and-status    ROFF_ACC___ACCOUNT_DOING_ROW)
+                                  (account-turn-on-warmth                       ROFF_ACC___ACCOUNT_DOING_ROW)
+                                  (account-same-marked-for-selfdestruct         ROFF_ACC___ACCOUNT_DOING_ROW)
+                                  (DOM-SUB-stamps---standard                    ROFF_ACC___ACCOUNT_DOING_ROW 0)))))
 
 
 (defconstraint   account-instruction---trimming-case-garnishing-non-stack-row-undo-account-row
@@ -154,47 +157,47 @@
                    (if-not-zero (account-instruction---touches-foreign-account)
                                 (if-not-zero CONTEXT_WILL_REVERT
                                              (begin
-                                               (account-same-address-as                  ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                               (account-undo-balance-update              ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                               (account-undo-nonce-update                ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                               (account-undo-code-update                 ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                               (account-undo-deployment-status-update    ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                               (account-undo-warmth-update               ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
-                                               (account-same-marked-for-selfdestruct     ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW)
-                                               (DOM-SUB-stamps---revert-with-current     ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    1))))))
+                                               (account-same-address-as                  ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
+                                               (account-undo-balance-update              ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
+                                               (account-undo-nonce-update                ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
+                                               (account-undo-code-update                 ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
+                                               (account-undo-deployment-status-update    ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
+                                               (account-undo-warmth-update               ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
+                                               (account-same-marked-for-selfdestruct     ROFF_ACC___ACCOUNT_UNDOING_ROW)
+                                               (DOM-SUB-stamps---revert-with-current     ROFF_ACC___ACCOUNT_UNDOING_ROW    1))))))
 
 (defconstraint   account-instruction---non-trim-case
                  (:guard (account-instruction---standard-hypothesis))
                  ;;
                  (begin
-                   (if-not-zero (account-instruction---no-trimming)
+                   (if-not-zero (account-instruction---touches-current-account)
                                 (if-zero XAHOY
                                          (begin
-                                           (read-context-data                            1 CONTEXT_NUMBER)
-                                           (account-same-balance                         ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
-                                           (account-same-nonce                           ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
-                                           (account-same-code                            ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
-                                           (account-same-deployment-number-and-status    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
-                                           (account-turn-on-warmth                       ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
-                                           (account-same-marked-for-selfdestruct         ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
-                                           (DOM-SUB-stamps---standard                    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW    0)
+                                           (read-context-data                            ROFF_ACC___CONTEXT_ROW            CONTEXT_NUMBER)
+                                           (account-same-balance                         ROFF_ACC___ACCOUNT_READING_ROW)
+                                           (account-same-nonce                           ROFF_ACC___ACCOUNT_READING_ROW)
+                                           (account-same-code                            ROFF_ACC___ACCOUNT_READING_ROW)
+                                           (account-same-deployment-number-and-status    ROFF_ACC___ACCOUNT_READING_ROW)
+                                           (account-turn-on-warmth                       ROFF_ACC___ACCOUNT_READING_ROW)
+                                           (account-same-marked-for-selfdestruct         ROFF_ACC___ACCOUNT_READING_ROW)
+                                           (DOM-SUB-stamps---standard                    ROFF_ACC___ACCOUNT_READING_ROW    0)
                                            (if-zero (account-instruction---is-CODESIZE)
                                                     ;; DEC_FLAG_4 = 0
                                                     (begin
-                                                      (eq!  (shift account/ADDRESS_HI    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW) (account-instruction---account-address-hi))
-                                                      (eq!  (shift account/ADDRESS_LO    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW) (account-instruction---account-address-lo)))
+                                                      (eq!  (shift account/ADDRESS_HI    ROFF_ACC___ACCOUNT_READING_ROW) (account-instruction---account-address-hi))
+                                                      (eq!  (shift account/ADDRESS_LO    ROFF_ACC___ACCOUNT_READING_ROW) (account-instruction---account-address-lo)))
                                                     ;; DEC_FLAG_4 = 1
                                                     (begin
-                                                      (eq!  (shift account/ADDRESS_HI    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-hi))
-                                                      (eq!  (shift account/ADDRESS_LO    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-lo)))))))))
+                                                      (eq!  (shift account/ADDRESS_HI    ROFF_ACC___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-hi))
+                                                      (eq!  (shift account/ADDRESS_LO    ROFF_ACC___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-lo)))))))))
 
 
-(defun    (account-instruction---foreign-balance)         (shift     account/BALANCE                          ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW  ))
-(defun    (account-instruction---foreign-code-size)       (shift  (* account/CODE_SIZE    account/HAS_CODE)   ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW  ))
-(defun    (account-instruction---foreign-code-hash-hi)    (shift  (* account/CODE_HASH_HI account/EXISTS)     ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW  ))
-(defun    (account-instruction---foreign-code-hash-lo)    (shift  (* account/CODE_HASH_LO account/EXISTS)     ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW  ))
-(defun    (account-instruction---current-code-size)       (shift     account/CODE_SIZE                        ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW))
-(defun    (account-instruction---current-balance)         (shift     account/BALANCE                          ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW))
+(defun    (account-instruction---foreign-balance)         (shift     account/BALANCE                          ROFF_ACC___ACCOUNT_DOING_ROW  ))
+(defun    (account-instruction---foreign-code-size)       (shift  (* account/CODE_SIZE    account/HAS_CODE)   ROFF_ACC___ACCOUNT_DOING_ROW  ))
+(defun    (account-instruction---foreign-code-hash-hi)    (shift  (* account/CODE_HASH_HI account/EXISTS)     ROFF_ACC___ACCOUNT_DOING_ROW  ))
+(defun    (account-instruction---foreign-code-hash-lo)    (shift  (* account/CODE_HASH_LO account/EXISTS)     ROFF_ACC___ACCOUNT_DOING_ROW  ))
+(defun    (account-instruction---current-code-size)       (shift     account/CODE_SIZE                        ROFF_ACC___ACCOUNT_READING_ROW))
+(defun    (account-instruction---current-balance)         (shift     account/BALANCE                          ROFF_ACC___ACCOUNT_READING_ROW))
 
 
 (defconstraint   account-instruction---value-constraints---the-BALANCE-case

--- a/hub/constraints/instruction-handling/acc.lisp
+++ b/hub/constraints/instruction-handling/acc.lisp
@@ -23,21 +23,42 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-(defun (account-instruction-requires-trimming)        (+ [ stack/DEC_FLAG 1 ]
-                                                         [ stack/DEC_FLAG 2 ]
-                                                         [ stack/DEC_FLAG 3 ]))
-(defun (account-instruction-no-trimming)              (- stack/ACC_FLAG (account-instruction-requires-trimming)))
-(defun (account-instruction-raw-address-hi)           [ stack/STACK_ITEM_VALUE_HI 1 ])
-(defun (account-instruction-raw-address-lo)           [ stack/STACK_ITEM_VALUE_LO 1 ])
-(defun (account-instruction-account-address-hi)       context/ACCOUNT_ADDRESS_HI)
-(defun (account-instruction-account-address-lo)       context/ACCOUNT_ADDRESS_LO)
-(defun (account-instruction-byte-code-address-hi)     context/BYTE_CODE_ADDRESS_HI)
-(defun (account-instruction-byte-code-address-lo)     context/BYTE_CODE_ADDRESS_LO)
-(defun (account-instruction-address-warmth)           account/WARMTH)
-(defun (account-instruction-decoded-flags-sum)        (+ [ stack/DEC_FLAG 1 ]
-                                                         [ stack/DEC_FLAG 2 ]
-                                                         [ stack/DEC_FLAG 3 ]
-                                                         [ stack/DEC_FLAG 4 ])) ;; ""
+(defconst
+  ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW            1
+  ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW    2
+
+  ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW      1
+  ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    2
+  )
+
+
+(defun (account-instruction---is-BALANCE)               [ stack/DEC_FLAG 1 ] )
+(defun (account-instruction---is-EXTCODESIZE)           [ stack/DEC_FLAG 2 ] )
+(defun (account-instruction---is-EXTCODEHASH)           [ stack/DEC_FLAG 3 ] )
+(defun (account-instruction---is-CODESIZE)              [ stack/DEC_FLAG 4 ] )
+(defun (account-instruction---raw-address-hi)           [ stack/STACK_ITEM_VALUE_HI 1 ])
+(defun (account-instruction---raw-address-lo)           [ stack/STACK_ITEM_VALUE_LO 1 ])
+(defun (account-instruction---result-hi)                [ stack/STACK_ITEM_VALUE_HI 4 ])
+(defun (account-instruction---result-lo)                [ stack/STACK_ITEM_VALUE_LO 4 ]) ;; ""
+
+(defun (account-instruction---is-SELFBALANCE)           (-    1
+                                                              (account-instruction---is-BALANCE)
+                                                              (account-instruction---is-EXTCODESIZE)
+                                                              (account-instruction---is-EXTCODEHASH)
+                                                              (account-instruction---is-CODESIZE)))
+
+(defun (account-instruction---touches-foreign-account)  (+ (account-instruction---is-BALANCE)
+                                                           (account-instruction---is-EXTCODESIZE)
+                                                           (account-instruction---is-EXTCODEHASH)))
+(defun (account-instruction---touches-current-account)  (+ (account-instruction---is-CODESIZE)
+                                                           (account-instruction---is-SELFBALANCE)))
+
+(defun (account-instruction---no-trimming)              (- stack/ACC_FLAG (account-instruction---touches-foreign-account)))
+(defun (account-instruction---account-address-hi)       (shift   context/ACCOUNT_ADDRESS_HI     ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW))
+(defun (account-instruction---account-address-lo)       (shift   context/ACCOUNT_ADDRESS_LO     ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW))
+(defun (account-instruction---byte-code-address-hi)     (shift   context/BYTE_CODE_ADDRESS_HI   ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW))
+(defun (account-instruction---byte-code-address-lo)     (shift   context/BYTE_CODE_ADDRESS_LO   ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW))
+(defun (account-instruction---foreign-address-warmth)   (shift   account/WARMTH                 ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -47,135 +68,171 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-(defun (account-instruction-standard-hypothesis) (* PEEK_AT_STACK
-                                                    stack/ACC_FLAG
-                                                    (- 1 stack/SUX stack/SOX)))
+(defun (account-instruction---standard-hypothesis) (* PEEK_AT_STACK
+                                                      stack/ACC_FLAG
+                                                      (- 1 stack/SUX stack/SOX)))
 
-(defun (account-instruction-unexceptional) (* (account-instruction-standard-hypothesis)
-                                              (- 1 XAHOY)))
+(defun (account-instruction---unexceptional) (* (account-instruction---standard-hypothesis)
+                                                (- 1 XAHOY)))
 
-(defconstraint   account-instruction-setting-the-stack-pattern                              (:guard (account-instruction-standard-hypothesis))
+(defconstraint   account-instruction---setting-the-stack-pattern
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
                  (begin
-                   (if-not-zero (account-instruction-requires-trimming) (stack-pattern-1-1))
-                   (if-not-zero (account-instruction-no-trimming)       (stack-pattern-0-1))))
+                   (if-not-zero (account-instruction---touches-foreign-account) (stack-pattern-1-1))
+                   (if-not-zero (account-instruction---no-trimming)             (stack-pattern-0-1))))
 
-(defconstraint   account-instruction-setting-allowable-exceptions                           (:guard (account-instruction-standard-hypothesis))
+(defconstraint   account-instruction---setting-allowable-exceptions
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
                  (eq! XAHOY stack/OOGX))
 
-(defconstraint   account-instruction-setting-NSR                                            (:guard (account-instruction-standard-hypothesis))
+(defconstraint   account-instruction---setting-NSR
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
                  (begin
-                   (if-not-zero (account-instruction-requires-trimming)
-                                (eq! NSR (+ 1 CONTEXT_WILL_REVERT CMC)))
-                   (if-not-zero (account-instruction-no-trimming)
-                                (eq! NSR (+ 1 (- 1 CMC))))
-                   (debug (eq! XAHOY CMC))
-                   (debug (eq! XAHOY stack/OOGX))))
+                   (if-not-zero    (account-instruction---touches-foreign-account)    (eq! NSR (+ 1 CONTEXT_WILL_REVERT CMC)))
+                   (if-not-zero    (account-instruction---no-trimming)                (eq! NSR (+ 1 (- 1 CMC))))
+                   (debug          (eq! XAHOY CMC))
+                   (debug          (eq! XAHOY stack/OOGX))))
 
-(defconstraint   account-instruction-setting-peeking-flags                                  (:guard (account-instruction-standard-hypothesis))
+(defconstraint   account-instruction---setting-peeking-flags
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
                  (begin
-                   (if-not-zero (account-instruction-requires-trimming)
+                   (if-not-zero (account-instruction---touches-foreign-account)
                                 (if-zero CONTEXT_WILL_REVERT
                                          (eq! NSR
-                                              (+        (shift PEEK_AT_ACCOUNT 1)
-                                                 (* CMC (shift PEEK_AT_CONTEXT 2))))
+                                              (+        (shift PEEK_AT_ACCOUNT        ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                                        (* CMC (shift PEEK_AT_CONTEXT 2))))
                                          (eq! NSR
-                                              (+        (shift PEEK_AT_ACCOUNT 1)
-                                                        (shift PEEK_AT_ACCOUNT 2)
-                                                 (* CMC (shift PEEK_AT_CONTEXT 3))))))
-                   (if-not-zero (account-instruction-no-trimming)
+                                              (+        (shift PEEK_AT_ACCOUNT        ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                                        (shift PEEK_AT_ACCOUNT        ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW)
+                                                        (* CMC (shift PEEK_AT_CONTEXT 3))))))
+                   (if-not-zero (account-instruction---no-trimming)
                                 (if-zero XAHOY
                                          (eq! NSR
-                                              (+ (shift PEEK_AT_CONTEXT 1)
-                                                 (shift PEEK_AT_ACCOUNT 2)))
+                                              (+ (shift    PEEK_AT_CONTEXT    ROW_OFFSET___ACC_FAMILY___CONTEXT_ROW)
+                                                 (shift    PEEK_AT_ACCOUNT    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)))
                                          (eq! NSR
-                                              (shift PEEK_AT_CONTEXT 1))))))
+                                              (shift PEEK_AT_CONTEXT    1))))))
 
-(defconstraint   account-instruction-setting-gas-cost                                       (:guard (account-instruction-standard-hypothesis))
+(defconstraint   account-instruction---setting-gas-cost
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
                  (begin
-                   (if-not-zero (account-instruction-requires-trimming)
+                   (if-not-zero (account-instruction---touches-foreign-account)
                                 (eq! GAS_COST
-                                     (+ (*      (account-instruction-address-warmth)  GAS_CONST_G_WARM_ACCESS)
-                                        (* (- 1 (account-instruction-address-warmth)) GAS_CONST_G_COLD_ACCOUNT_ACCESS))))
-                   (if-not-zero (account-instruction-no-trimming)
+                                     (+ (*      (account-instruction---foreign-address-warmth)  GAS_CONST_G_WARM_ACCESS)
+                                        (* (- 1 (account-instruction---foreign-address-warmth)) GAS_CONST_G_COLD_ACCOUNT_ACCESS))))
+                   (if-not-zero (account-instruction---no-trimming)
                                 (eq! GAS_COST
                                      stack/STATIC_GAS))))
 
-(defconstraint   account-instruction-trimming-case-garnishing-non-stack-row-make-account-row   (:guard (account-instruction-standard-hypothesis))
+(defconstraint   account-instruction---trimming-case-garnishing-non-stack-row-make-account-row
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
                  (begin
-                   (if-not-zero (account-instruction-requires-trimming)
+                   (if-not-zero (account-instruction---touches-foreign-account)
                                 (begin
-                                  (eq! account/ROMLEX_FLAG 1)
-                                  (eq! account/TRM_RAW_ADDRESS_HI [ stack/STACK_ITEM_VALUE_HI 1 ])
-                                  (eq! account/ADDRESS_LO         [ stack/STACK_ITEM_VALUE_LO 1 ]) ;;""
-                                  (account-same-balance                         1)
-                                  (account-same-nonce                           1)
-                                  (account-same-code                            1)
-                                  (account-same-deployment-number-and-status    1)
-                                  (account-turn-on-warmth                       1)
-                                  (account-same-marked-for-selfdestruct         1)
-                                  (DOM-SUB-stamps---standard                    1 0)))))
+                                  (eq! account/ROMLEX_FLAG            1)
+                                  (eq! account/TRM_RAW_ADDRESS_HI    (account-instruction---raw-address-hi))
+                                  (eq! account/ADDRESS_LO            (account-instruction---raw-address-lo))
+                                  (account-same-balance                         ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                  (account-same-nonce                           ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                  (account-same-code                            ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                  (account-same-deployment-number-and-status    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                  (account-turn-on-warmth                       ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                  (account-same-marked-for-selfdestruct         ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                  (DOM-SUB-stamps---standard                    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW 0)))))
 
 
-(defconstraint   account-instruction-trimming-case-garnishing-non-stack-row-undo-account-row   (:guard (account-instruction-standard-hypothesis))
+(defconstraint   account-instruction---trimming-case-garnishing-non-stack-row-undo-account-row
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
                  (begin
-                   (if-not-zero (account-instruction-requires-trimming)
+                   (if-not-zero (account-instruction---touches-foreign-account)
                                 (if-not-zero CONTEXT_WILL_REVERT
                                              (begin
-                                               (account-same-address-as                2 1)
-                                               (account-undo-balance-update            2 1)
-                                               (account-undo-nonce-update              2 1)
-                                               (account-undo-code-update               2 1)
-                                               (account-undo-deployment-status-update  2 1)
-                                               (account-undo-warmth-update             2 1)
-                                               (account-same-marked-for-selfdestruct   2  )
-                                               (DOM-SUB-stamps---revert-with-current   2 1))))))
+                                               (account-same-address-as                  ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                               (account-undo-balance-update              ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                               (account-undo-nonce-update                ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                               (account-undo-code-update                 ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                               (account-undo-deployment-status-update    ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                               (account-undo-warmth-update               ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW)
+                                               (account-same-marked-for-selfdestruct     ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW)
+                                               (DOM-SUB-stamps---revert-with-current     ROW_OFFSET___ACC_FAMILY___ACCOUNT_UNDOING_ROW    1))))))
 
-(defconstraint   account-instruction-non-trim-case                                          (:guard (account-instruction-standard-hypothesis))
+(defconstraint   account-instruction---non-trim-case
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
                  (begin
-                   (if-not-zero (account-instruction-no-trimming)
+                   (if-not-zero (account-instruction---no-trimming)
                                 (if-zero XAHOY
                                          (begin
-                                           (read-context-data                          1 CONTEXT_NUMBER)
-                                           (account-same-balance                       2)
-                                           (account-same-nonce                         2)
-                                           (account-same-code                          2)
-                                           (account-same-deployment-number-and-status  2)
-                                           (account-turn-on-warmth                     2)
-                                           (account-same-marked-for-selfdestruct       2)
-                                           (DOM-SUB-stamps---standard                  2 0)
-                                           (if-zero [ stack/DEC_FLAG 4 ]
+                                           (read-context-data                            1 CONTEXT_NUMBER)
+                                           (account-same-balance                         ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
+                                           (account-same-nonce                           ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
+                                           (account-same-code                            ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
+                                           (account-same-deployment-number-and-status    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
+                                           (account-turn-on-warmth                       ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
+                                           (account-same-marked-for-selfdestruct         ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)
+                                           (DOM-SUB-stamps---standard                    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW    0)
+                                           (if-zero (account-instruction---is-CODESIZE)
                                                     ;; DEC_FLAG_4 = 0
                                                     (begin
-                                                      (eq!  (shift account/ADDRESS_HI  2) (account-instruction-account-address-hi))
-                                                      (eq!  (shift account/ADDRESS_LO  2) (account-instruction-account-address-lo)))
+                                                      (eq!  (shift account/ADDRESS_HI    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW) (account-instruction---account-address-hi))
+                                                      (eq!  (shift account/ADDRESS_LO    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW) (account-instruction---account-address-lo)))
                                                     ;; DEC_FLAG_4 = 1
                                                     (begin
-                                                      (eq!  (shift account/ADDRESS_HI  2)  (account-instruction-byte-code-address-hi))
-                                                      (eq!  (shift account/ADDRESS_LO  2)  (account-instruction-byte-code-address-lo)))))))))
+                                                      (eq!  (shift account/ADDRESS_HI    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-hi))
+                                                      (eq!  (shift account/ADDRESS_LO    ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-lo)))))))))
 
-(defconstraint   account-instruction-value-constraints                                      (:guard (account-instruction-unexceptional))
-                 (begin
-                   (if-not-zero [ stack/DEC_FLAG 1 ]
-                                (begin
-                                  (eq!  [ stack/STACK_ITEM_VALUE_HI 4 ] 0)
-                                  (eq!  [ stack/STACK_ITEM_VALUE_LO 4 ] (shift account/BALANCE 1))))
-                   ;;
-                   (if-not-zero [ stack/DEC_FLAG 2 ]
-                                (begin
-                                  (eq!  [ stack/STACK_ITEM_VALUE_HI 4 ] 0)
-                                  (eq!  [ stack/STACK_ITEM_VALUE_LO 4 ] (shift  (* account/CODE_SIZE account/HAS_CODE) 1))))
-                   ;;
-                   (if-not-zero [ stack/DEC_FLAG 3 ]
-                                (begin
-                                  (eq!  [ stack/STACK_ITEM_VALUE_HI 4 ] (shift  (* account/CODE_HASH_HI account/EXISTS)  1))
-                                  (eq!  [ stack/STACK_ITEM_VALUE_LO 4 ] (shift  (* account/CODE_HASH_LO account/EXISTS)  1))))
-                   ;;
-                   (if-not-zero [ stack/DEC_FLAG 4 ]
-                                (begin
-                                  (eq!  [ stack/STACK_ITEM_VALUE_HI 4 ] 0)
-                                  (eq!  [ stack/STACK_ITEM_VALUE_LO 4 ] (shift account/CODE_SIZE 2))))
-                   ;;
-                   (if-not-zero (- 1 (account-instruction-decoded-flags-sum))
-                                (begin
-                                  (eq!  [ stack/STACK_ITEM_VALUE_HI 4 ] 0)
-                                  (eq!  [ stack/STACK_ITEM_VALUE_LO 4 ] (shift account/CODE_SIZE 2))))))
+
+(defun    (account-instruction---foreign-balance)         (shift     account/BALANCE                          ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW  ))
+(defun    (account-instruction---foreign-code-size)       (shift  (* account/CODE_SIZE    account/HAS_CODE)   ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW  ))
+(defun    (account-instruction---foreign-code-hash-hi)    (shift  (* account/CODE_HASH_HI account/EXISTS)     ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW  ))
+(defun    (account-instruction---foreign-code-hash-lo)    (shift  (* account/CODE_HASH_LO account/EXISTS)     ROW_OFFSET___ACC_FAMILY___ACCOUNT_DOING_ROW  ))
+(defun    (account-instruction---current-code-size)       (shift     account/CODE_SIZE                        ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW))
+(defun    (account-instruction---current-balance)         (shift     account/BALANCE                          ROW_OFFSET___ACC_FAMILY___ACCOUNT_READING_ROW))
+
+
+(defconstraint   account-instruction---value-constraints---the-BALANCE-case
+                 (:guard (account-instruction---unexceptional))
+                 ;;
+                 (if-not-zero (account-instruction---is-BALANCE)
+                              (begin
+                                (eq!  (account-instruction---result-hi)    0)
+                                (eq!  (account-instruction---result-lo)    (account-instruction---foreign-balance)))))
+
+(defconstraint   account-instruction---value-constraints---the-EXTCODESIZE-case
+                 (:guard (account-instruction---unexceptional))
+                 ;;
+                 (if-not-zero (account-instruction---is-EXTCODESIZE)
+                              (begin
+                                (eq!   (account-instruction---result-hi)   0)
+                                (eq!   (account-instruction---result-lo)   (account-instruction---foreign-code-size)))))
+
+(defconstraint   account-instruction---value-constraints---the-EXTCODEHASH-case
+                 (:guard (account-instruction---unexceptional))
+                 ;;
+                 (if-not-zero (account-instruction---is-EXTCODEHASH)
+                              (begin
+                                (eq!   (account-instruction---result-hi)   (account-instruction---foreign-code-hash-hi))
+                                (eq!   (account-instruction---result-lo)   (account-instruction---foreign-code-hash-lo)))))
+
+(defconstraint   account-instruction---value-constraints---the-CODESIZE-case
+                 (:guard (account-instruction---unexceptional))
+                 ;;
+                 (if-not-zero (account-instruction---is-CODESIZE)
+                              (begin
+                                (eq!   (account-instruction---result-hi)   0)
+                                (eq!   (account-instruction---result-lo)   (account-instruction---current-code-size)))))
+
+(defconstraint   account-instruction---value-constraints---the-SELFBALANCE-case
+                 (:guard (account-instruction---unexceptional))
+                 ;;
+                 (if-not-zero (account-instruction---is-SELFBALANCE)
+                              (begin
+                                (eq!   (account-instruction---result-hi)   0)
+                                (eq!   (account-instruction---result-lo)   (account-instruction---current-balance)))))

--- a/hub/constraints/instruction-handling/acc.lisp
+++ b/hub/constraints/instruction-handling/acc.lisp
@@ -88,37 +88,45 @@
 (defconstraint   account-instruction---setting-allowable-exceptions
                  (:guard (account-instruction---standard-hypothesis))
                  ;;
-                 (eq! XAHOY stack/OOGX))
+                 (begin
+                   (eq!    XAHOY stack/OOGX)
+                   (debug  (eq! XAHOY CMC))))
 
-(defconstraint   account-instruction---setting-NSR
+(defconstraint   account-instruction---foreign-address-opcode---setting-NSR
                  (:guard (account-instruction---standard-hypothesis))
                  ;;
-                 (begin
-                   (if-not-zero    (account-instruction---touches-foreign-account)    (eq! NSR (+ 1 CONTEXT_WILL_REVERT CMC)))
-                   (if-not-zero    (account-instruction---touches-current-account)    (eq! NSR (+ 1 (- 1 CMC))))
-                   (debug          (eq! XAHOY CMC))
-                   (debug          (eq! XAHOY stack/OOGX))))
+                 (if-not-zero    (account-instruction---touches-foreign-account)
+                                 (eq!    NSR
+                                         (+ 1 (* CONTEXT_WILL_REVERT (+ 1 CMC))))))
 
-(defconstraint   account-instruction---setting-peeking-flags
+(defconstraint   account-instruction---current-address-opcode---setting-NSR
+                 (:guard (account-instruction---standard-hypothesis))
+                 (if-not-zero    (account-instruction---touches-current-account)
+                                 (eq!    NSR
+                                         (- 2 CMC))))
+
+(defconstraint   account-instruction---foreign-address-opcode---setting-peeking-flags
                  (:guard (account-instruction---standard-hypothesis))
                  ;;
-                 (begin
-                   (if-not-zero (account-instruction---touches-foreign-account)
-                                (if-zero CONTEXT_WILL_REVERT
-                                         (eq! NSR
-                                              (+        (shift PEEK_AT_ACCOUNT        ROFF_ACC___ACCOUNT_DOING_ROW)
-                                                        (* CMC (shift PEEK_AT_CONTEXT 2))))
-                                         (eq! NSR
-                                              (+        (shift PEEK_AT_ACCOUNT        ROFF_ACC___ACCOUNT_DOING_ROW)
-                                                        (shift PEEK_AT_ACCOUNT        ROFF_ACC___ACCOUNT_UNDOING_ROW)
-                                                        (* CMC (shift PEEK_AT_CONTEXT 3))))))
-                   (if-not-zero (account-instruction---touches-current-account)
-                                (if-zero XAHOY
-                                         (eq! NSR
-                                              (+ (shift    PEEK_AT_CONTEXT    ROFF_ACC___CONTEXT_ROW)
-                                                 (shift    PEEK_AT_ACCOUNT    ROFF_ACC___ACCOUNT_READING_ROW)))
-                                         (eq! NSR
-                                              (shift       PEEK_AT_CONTEXT    ROFF_ACC___CONTEXT_ROW))))))
+                 (if-not-zero (account-instruction---touches-foreign-account)
+                              (if-zero CONTEXT_WILL_REVERT
+                                       (eq! NSR
+                                            (shift PEEK_AT_ACCOUNT              ROFF_ACC___ACCOUNT_DOING_ROW))
+                                       (eq! NSR
+                                            (+    (shift PEEK_AT_ACCOUNT        ROFF_ACC___ACCOUNT_DOING_ROW)
+                                                  (shift PEEK_AT_ACCOUNT        ROFF_ACC___ACCOUNT_UNDOING_ROW)
+                                                  (* CMC (shift PEEK_AT_CONTEXT 3)))))))
+
+(defconstraint   account-instruction---current-address-opcode---setting-peeking-flags
+                 (:guard (account-instruction---standard-hypothesis))
+                 ;;
+                 (if-not-zero (account-instruction---touches-current-account)
+                              (if-zero XAHOY
+                                       (eq! NSR
+                                            (+ (shift    PEEK_AT_CONTEXT    ROFF_ACC___CONTEXT_ROW)
+                                               (shift    PEEK_AT_ACCOUNT    ROFF_ACC___ACCOUNT_READING_ROW)))
+                                       (eq! NSR
+                                            (shift       PEEK_AT_CONTEXT    ROFF_ACC___CONTEXT_ROW)))))
 
 (defconstraint   account-instruction---setting-gas-cost
                  (:guard (account-instruction---standard-hypothesis))
@@ -132,31 +140,32 @@
                                 (eq! GAS_COST
                                      stack/STATIC_GAS))))
 
-(defconstraint   account-instruction---trimming-case-garnishing-non-stack-row-make-account-row
+(defconstraint   account-instruction---foreign-address-opcode---doing-account-row
                  (:guard (account-instruction---standard-hypothesis))
                  ;;
                  (begin
                    (if-not-zero (account-instruction---touches-foreign-account)
                                 (begin
-                                  (eq! account/ROMLEX_FLAG            1)
-                                  (eq! account/TRM_RAW_ADDRESS_HI    (account-instruction---raw-address-hi))
-                                  (eq! account/ADDRESS_LO            (account-instruction---raw-address-lo))
+                                  (eq! (shift account/ROMLEX_FLAG               ROFF_ACC___ACCOUNT_DOING_ROW)   0)
+                                  (eq! (shift account/TRM_RAW_ADDRESS_HI        ROFF_ACC___ACCOUNT_DOING_ROW)   (account-instruction---raw-address-hi))
+                                  (eq! (shift account/ADDRESS_LO                ROFF_ACC___ACCOUNT_DOING_ROW)   (account-instruction---raw-address-lo))
                                   (account-same-balance                         ROFF_ACC___ACCOUNT_DOING_ROW)
                                   (account-same-nonce                           ROFF_ACC___ACCOUNT_DOING_ROW)
                                   (account-same-code                            ROFF_ACC___ACCOUNT_DOING_ROW)
                                   (account-same-deployment-number-and-status    ROFF_ACC___ACCOUNT_DOING_ROW)
                                   (account-turn-on-warmth                       ROFF_ACC___ACCOUNT_DOING_ROW)
                                   (account-same-marked-for-selfdestruct         ROFF_ACC___ACCOUNT_DOING_ROW)
-                                  (DOM-SUB-stamps---standard                    ROFF_ACC___ACCOUNT_DOING_ROW 0)))))
+                                  (DOM-SUB-stamps---standard                    ROFF_ACC___ACCOUNT_DOING_ROW    0)))))
 
 
-(defconstraint   account-instruction---trimming-case-garnishing-non-stack-row-undo-account-row
+(defconstraint   account-instruction---foreign-address-opcode---undoing-account-row
                  (:guard (account-instruction---standard-hypothesis))
                  ;;
                  (begin
                    (if-not-zero (account-instruction---touches-foreign-account)
                                 (if-not-zero CONTEXT_WILL_REVERT
                                              (begin
+                                               (eq! (shift account/ROMLEX_FLAG           ROFF_ACC___ACCOUNT_UNDOING_ROW)   0)
                                                (account-same-address-as                  ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
                                                (account-undo-balance-update              ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
                                                (account-undo-nonce-update                ROFF_ACC___ACCOUNT_UNDOING_ROW    ROFF_ACC___ACCOUNT_DOING_ROW)
@@ -166,14 +175,20 @@
                                                (account-same-marked-for-selfdestruct     ROFF_ACC___ACCOUNT_UNDOING_ROW)
                                                (DOM-SUB-stamps---revert-with-current     ROFF_ACC___ACCOUNT_UNDOING_ROW    1))))))
 
-(defconstraint   account-instruction---non-trim-case
+(defconstraint   account-instruction---current-address-opcode---unexceptional-case---setting-context-row
+                 (:guard (account-instruction---standard-hypothesis))
+                 (if-not-zero (account-instruction---touches-current-account)
+                              (if-zero XAHOY
+                                       (read-context-data                                ROFF_ACC___CONTEXT_ROW            CONTEXT_NUMBER))))
+
+(defconstraint   account-instruction---current-address-opcode---unexceptional-case---setting-account-row
                  (:guard (account-instruction---standard-hypothesis))
                  ;;
                  (begin
                    (if-not-zero (account-instruction---touches-current-account)
                                 (if-zero XAHOY
                                          (begin
-                                           (read-context-data                            ROFF_ACC___CONTEXT_ROW            CONTEXT_NUMBER)
+                                           (eq! (shift account/ROMLEX_FLAG               ROFF_ACC___ACCOUNT_READING_ROW)   0)
                                            (account-same-balance                         ROFF_ACC___ACCOUNT_READING_ROW)
                                            (account-same-nonce                           ROFF_ACC___ACCOUNT_READING_ROW)
                                            (account-same-code                            ROFF_ACC___ACCOUNT_READING_ROW)
@@ -181,15 +196,15 @@
                                            (account-turn-on-warmth                       ROFF_ACC___ACCOUNT_READING_ROW)
                                            (account-same-marked-for-selfdestruct         ROFF_ACC___ACCOUNT_READING_ROW)
                                            (DOM-SUB-stamps---standard                    ROFF_ACC___ACCOUNT_READING_ROW    0)
-                                           (if-zero (account-instruction---is-CODESIZE)
-                                                    ;; DEC_FLAG_4 = 0
+                                           (if-not-zero (account-instruction---is-CODESIZE)
                                                     (begin
                                                       (eq!  (shift account/ADDRESS_HI    ROFF_ACC___ACCOUNT_READING_ROW) (account-instruction---account-address-hi))
-                                                      (eq!  (shift account/ADDRESS_LO    ROFF_ACC___ACCOUNT_READING_ROW) (account-instruction---account-address-lo)))
-                                                    ;; DEC_FLAG_4 = 1
+                                                      (eq!  (shift account/ADDRESS_LO    ROFF_ACC___ACCOUNT_READING_ROW) (account-instruction---account-address-lo))))
+                                           (if-not-zero (account-instruction---is-SELFBALANCE)
                                                     (begin
                                                       (eq!  (shift account/ADDRESS_HI    ROFF_ACC___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-hi))
-                                                      (eq!  (shift account/ADDRESS_LO    ROFF_ACC___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-lo)))))))))
+                                                      (eq!  (shift account/ADDRESS_LO    ROFF_ACC___ACCOUNT_READING_ROW)  (account-instruction---byte-code-address-lo)))
+                                                    ))))))
 
 
 (defun    (account-instruction---foreign-balance)         (shift     account/BALANCE                          ROFF_ACC___ACCOUNT_DOING_ROW  ))


### PR DESCRIPTION
- more shorthands, fewer `[ stack/DEC_FLAG k ]`'s and `[ stack/STACK_ITEM_VALUE k ]`'s
- boolean flag per instruction
- using the `account-instruction---bla` convention
- named constants for row offsets
- splitting of some constraints
- force `account/ROM_LEX_FLAG = 0` whenever possible
- changed the `NSR` of instructions that touch a current account (`CODESIZE`, `SELFBALANCE`)
- **Bug-fix:** `SELFBALANCE` was receiving the wrong value
- **Bug-fix:** several shorthands were missing `shift`'s ... !