### PR TITLE
Remove `(vanishes! 0)`

### DIFF
--- a/ecdata/constraints.lisp
+++ b/ecdata/constraints.lisp
@@ -287,7 +287,6 @@
 
 (defconstraint stamp-increment-sanity-check ()
   (begin 
-    (vanishes! 0)
     (debug (any! (will-remain-constant! STAMP) (will-inc! STAMP 1))))) ;; implied by the constraint below
 
 (defconstraint stamp-increment ()

--- a/hub/constraints/instruction-handling/jump.lisp
+++ b/hub/constraints/instruction-handling/jump.lisp
@@ -60,7 +60,6 @@
 ;; TODO: remove ugly hack
 (defconstraint jump-instruction---allowable-exceptions                        (:guard (jump-instruction---no-stack-exception))
                (begin
-                 (vanishes! 0)
                  (debug (eq! XAHOY (+ stack/OOGX stack/JUMPX)))))
 
 

--- a/hub/constraints/instruction-handling/log.lisp
+++ b/hub/constraints/instruction-handling/log.lisp
@@ -51,7 +51,7 @@
                                          [ stack/DEC_FLAG 4 ])) ;; ""
 
 (defconstraint    log-instruction---allowable-exceptions                             (:guard (log-instruction---standard-hypothesis))         ;; TODO: solo debug constraint plz
-                  (begin (vanishes! 0)
+                  (begin
                          (debug (eq! XAHOY (+ stack/STATICX
                                               stack/MXPX
                                               stack/OOGX)))))


### PR DESCRIPTION
These are no longer necessary because the relevant bug in `corset` has been fixed already.