### PR TITLE
Make the constraints compile again

### DIFF
--- a/hub/constraints/instruction-handling/jump.lisp
+++ b/hub/constraints/instruction-handling/jump.lisp
@@ -60,7 +60,7 @@
 ;; TODO: remove ugly hack
 (defconstraint jump-instruction---allowable-exceptions                        (:guard (jump-instruction---no-stack-exception))
                (begin
-                 (debug (eq! XAHOY (+ stack/OOGX stack/JUMPX)))))
+                 (eq! XAHOY (+ stack/OOGX stack/JUMPX))))
 
 
 (defconstraint jump-instruction---setting-the-gas-cost                        (:guard (jump-instruction---no-stack-exception))
@@ -69,8 +69,8 @@
 (defconstraint jump-instruction---setting-NSR                                 (:guard (jump-instruction---no-stack-exception))
                (if-not-zero (force-bin stack/OOGX)
                             ;; OOGX = 1
-                            (begin (eq! NSR CMC)
-                                   (debug (eq! NSR 1)))
+                            (begin (eq!        NSR CMC)
+                                   (debug (eq! NSR 1  )))
                             ;; OOGX = 0
                             (eq! NSR (+ 3 CMC))))
 

--- a/hub/constraints/instruction-handling/log.lisp
+++ b/hub/constraints/instruction-handling/log.lisp
@@ -51,10 +51,9 @@
                                          [ stack/DEC_FLAG 4 ])) ;; ""
 
 (defconstraint    log-instruction---allowable-exceptions                             (:guard (log-instruction---standard-hypothesis))         ;; TODO: solo debug constraint plz
-                  (begin
-                         (debug (eq! XAHOY (+ stack/STATICX
-                                              stack/MXPX
-                                              stack/OOGX)))))
+                  (eq! XAHOY (+ stack/STATICX
+                                stack/MXPX
+                                stack/OOGX)))
 
 (defconstraint    log-instruction---setting-NSR                                      (:guard (log-instruction---standard-hypothesis))
                   (if-zero (force-bin stack/STATICX)


### PR DESCRIPTION
Likely the aftermath of having erased some of the `(vanishes! 0)` constraints and having left the `(begin ...` stuff.