### PR TITLE
CODECOPY sanity check fix

### DIFF
--- a/hub/constraints/instruction-handling/copy/codecopy.lisp
+++ b/hub/constraints/instruction-handling/copy/codecopy.lisp
@@ -42,9 +42,10 @@
 
 (defconstraint    copy-instruction---CODECOPY---consistency-constraints---debug
                   (:guard (copy-instruction---standard-CODECOPY))
-                  (begin
-                    (eq!        (shift account/DEPLOYMENT_NUMBER      ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) (shift context/BYTE_CODE_DEPLOYMENT_NUMBER     ROFF_CODECOPY_NO_XAHOY_CONTEXT_ROW))
-                    (eq!        (shift account/DEPLOYMENT_STATUS      ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) (shift context/BYTE_CODE_DEPLOYMENT_STATUS     ROFF_CODECOPY_NO_XAHOY_CONTEXT_ROW))
-                    (eq!        (shift account/CODE_FRAGMENT_INDEX    ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) (shift context/BYTE_CODE_CODE_FRAGMENT_INDEX   ROFF_CODECOPY_NO_XAHOY_CONTEXT_ROW))
-                    (eq!        (shift account/CODE_FRAGMENT_INDEX    ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) CODE_FRAGMENT_INDEX)
-                    (debug (eq! (shift account/ROMLEX_FLAG            ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) 1))))
+                  (if-zero XAHOY
+                           (begin
+                             (eq!   (shift account/DEPLOYMENT_NUMBER      ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) (shift context/BYTE_CODE_DEPLOYMENT_NUMBER     ROFF_CODECOPY_NO_XAHOY_CONTEXT_ROW))
+                             (eq!   (shift account/DEPLOYMENT_STATUS      ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) (shift context/BYTE_CODE_DEPLOYMENT_STATUS     ROFF_CODECOPY_NO_XAHOY_CONTEXT_ROW))
+                             (eq!   (shift account/CODE_FRAGMENT_INDEX    ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) (shift context/BYTE_CODE_CODE_FRAGMENT_INDEX   ROFF_CODECOPY_NO_XAHOY_CONTEXT_ROW))
+                             (eq!   (shift account/CODE_FRAGMENT_INDEX    ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW) CODE_FRAGMENT_INDEX)
+                             (account-retrieve-code-fragment-index        ROFF_CODECOPY_NO_XAHOY_ACCOUNT_ROW))))


### PR DESCRIPTION
The sanity check constraints only apply to **unexceptional** CODECOPY instructions.