### PR TITLE
Fixed divergence from spec in the "return data size" macro for `ECADD`/`ECMUL`/`ECPAIRING`

### DIFF
--- a/hub/constraints/instruction-handling/call/precompiles/ec_add_mul_pairing/success_case.lisp
+++ b/hub/constraints/instruction-handling/call/precompiles/ec_add_mul_pairing/success_case.lisp
@@ -99,10 +99,6 @@
                                                                                              (*    PHASE_ECMUL_RESULT            (precompile-processing---ECADD_MUL_PAIRING---nontrivial-ECMUL))
                                                                                              (*    PHASE_ECPAIRING_RESULT        (precompile-processing---ECADD_MUL_PAIRING---nontrivial-ECPAIRING))))
 
-(defun    (precompile-processing---ECADD_MUL_PAIRING---return-data-reference-size)     (+    (*    ECADD_RETURN_DATA_SIZE        (precompile-processing---ECADD_MUL_PAIRING---nontrivial-ECADD))
-                                                                                             (*    ECMUL_RETURN_DATA_SIZE        (precompile-processing---ECADD_MUL_PAIRING---nontrivial-ECMUL))
-                                                                                             (*    ECPAIRING_RETURN_DATA_SIZE    (precompile-processing---ECADD_MUL_PAIRING---nontrivial-ECPAIRING))))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Miscellaneous-row i + 3 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -134,6 +130,10 @@
                                                                                     ;; exo_sum                                                                              ;; weighted exogenous module flag sum
                                                                                     ;; phase                                                                                ;; phase
                                                                                     )))
+
+(defun    (precompile-processing---ECADD_MUL_PAIRING---return-data-reference-size)     (+    (*    ECADD_RETURN_DATA_SIZE        scenario/PRC_ECADD    )
+                                                                                             (*    ECMUL_RETURN_DATA_SIZE        scenario/PRC_ECMUL    )
+                                                                                             (*    ECPAIRING_RETURN_DATA_SIZE    scenario/PRC_ECPAIRING)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Around page 326

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/56b702b3-8f46-4cc2-8b97-bfe80db41d99" />

The shorthand uses the PRC flags directly, not their "nontrivial" counterparts.