### PR TITLE
`EXTCODECOPY` requires the `CFI` as its `MMU_SRC_ID` only for addresses not currently under deployment

### DIFF
--- a/hub/constraints/instruction-handling/copy/generalities.lisp
+++ b/hub/constraints/instruction-handling/copy/generalities.lisp
@@ -216,7 +216,7 @@
 (defun (copy-instruction---source-id)         (+   (* (copy-instruction---is-CALLDATACOPY)      (copy-instruction---call-data-context))
                                                    (* (copy-instruction---is-RETURNDATACOPY)    (copy-instruction---return-data-context))
                                                    (* (copy-instruction---is-CODECOPY)          (copy-instruction---bytecode-address-code-fragment-index))
-                                                   (* (copy-instruction---is-EXTCODECOPY)       (copy-instruction---foreign-address-code-fragment-index))))
+                                                   (* (copy-instruction---is-EXTCODECOPY)       (copy-instruction---foreign-address-code-fragment-index)  (copy-instruction---foreign-address-has-code))))
 
 (defun (copy-instruction---reference-offset)  (+   (* (copy-instruction---is-CALLDATACOPY)      (copy-instruction---call-data-offset))
                                                    (* (copy-instruction---is-RETURNDATACOPY)    (copy-instruction---return-data-offset))))

--- a/hub/constraints/instruction-handling/copy/generalities.lisp
+++ b/hub/constraints/instruction-handling/copy/generalities.lisp
@@ -226,4 +226,5 @@
                                                    (* (copy-instruction---is-CODECOPY)          (copy-instruction---bytecode-address-code-size))
                                                    (* (copy-instruction---is-EXTCODECOPY)       (copy-instruction---foreign-address-code-size) (copy-instruction---foreign-address-has-code))))
 
-(defun (copy-instruction---exo-sum)           (*   (+ (copy-instruction---is-CODECOPY) (copy-instruction---is-EXTCODECOPY)) EXO_SUM_WEIGHT_ROM))
+(defun (copy-instruction---exo-sum)           (+   (* (copy-instruction---is-CODECOPY)          EXO_SUM_WEIGHT_ROM)
+                                                   (* (copy-instruction---is-EXTCODECOPY)       EXO_SUM_WEIGHT_ROM)))


### PR DESCRIPTION
Implements https://github.com/Consensys/linea-specification/pull/40