### PR TITLE
feat: enable build for `zkevm.go.bin`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ define.go: ${ZKEVM_MODULES}
 zkevm.bin: ${ZKEVM_MODULES}
 	${CORSET} compile -vv -o $@ ${ZKEVM_MODULES}
 
-zkevm.gob: ${ZKEVM_MODULES}
+zkevm.go.bin: ${ZKEVM_MODULES}
 	${GO_CORSET} compile -o $@ ${ZKEVM_MODULES}
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CORSET ?= corset
+GO_CORSET ?= go-corset
 
 HUB_COLUMNS :=  $(wildcard hub/columns/*lisp)
 
@@ -174,6 +175,9 @@ define.go: ${ZKEVM_MODULES}
 
 zkevm.bin: ${ZKEVM_MODULES}
 	${CORSET} compile -vv -o $@ ${ZKEVM_MODULES}
+
+zkevm.gob: ${ZKEVM_MODULES}
+	${GO_CORSET} compile -o $@ ${ZKEVM_MODULES}
 
 
 ZKEVM_MODULES_FOR_REFERENCE_TESTS := ${ALU} \

--- a/Makefile
+++ b/Makefile
@@ -217,5 +217,8 @@ ZKEVM_MODULES_FOR_REFERENCE_TESTS := ${ALU} \
 zkevm_for_reference_tests.bin: ${ZKEVM_MODULES_FOR_REFERENCE_TESTS}
 	${CORSET} compile -vv -o $@ ${ZKEVM_MODULES_FOR_REFERENCE_TESTS}
 
+zkevm_for_reference_tests.go.bin: ${ZKEVM_MODULES_FOR_REFERENCE_TESTS}
+	${GO_CORSET} compile -o $@ ${ZKEVM_MODULES_FOR_REFERENCE_TESTS}
+
 
 

--- a/bin/lookups/bin_into_binreftable.lisp
+++ b/bin/lookups/bin_into_binreftable.lisp
@@ -1,4 +1,4 @@
-(defpurefun (selector-bin-to-binreftable)
+(defun (selector-bin-to-binreftable)
   (+ bin.IS_AND bin.IS_OR bin.IS_XOR bin.IS_NOT))
 
 (deflookup

--- a/blockdata/constants-ethereum.lisp
+++ b/blockdata/constants-ethereum.lisp
@@ -1,6 +1,0 @@
-(module blockdata)
-
-;; TODO add reference to global constants
-(defconst GAS_LIMIT_MINIMUM 5000)
-
-(defconst GAS_LIMIT_MAXIMUM 0xffffffffffffffff)

--- a/blockdata/constants-linea.lisp
+++ b/blockdata/constants-linea.lisp
@@ -1,6 +1,0 @@
-(module blockdata)
-
-;; TODO add reference to global constants
-(defconst GAS_LIMIT_MINIMUM 61000000)
-
-(defconst GAS_LIMIT_MAXIMUM 2000000000)

--- a/blockdata/processing/gaslimit/ethereum.lisp
+++ b/blockdata/processing/gaslimit/ethereum.lisp
@@ -1,5 +1,9 @@
 (module blockdata)
 
+;; TODO add reference to global constants
+(defconst GAS_LIMIT_MINIMUM 5000)
+(defconst GAS_LIMIT_MAXIMUM 0xffffffffffffffff)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                 ;;
 ;;  3 Computations and checks      ;;

--- a/blockdata/processing/gaslimit/linea.lisp
+++ b/blockdata/processing/gaslimit/linea.lisp
@@ -1,5 +1,9 @@
 (module blockdata)
 
+;; TODO add reference to global constants
+(defconst GAS_LIMIT_MINIMUM 61000000)
+(defconst GAS_LIMIT_MAXIMUM 2000000000)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                              ;;
 ;;  3 Computations and checks   ;;

--- a/ecdata/constraints.lisp
+++ b/ecdata/constraints.lisp
@@ -453,8 +453,8 @@
                                      P_x_lo
                                      P_y_hi
                                      P_y_lo
-                                     P_x_square_hi
-                                     P_x_square_lo
+                                     P_y_square_hi
+                                     P_y_square_lo
                                      P_x_cube_plus_three_hi
                                      P_x_cube_plus_three_lo)
               (callToC1MembershipEXT k
@@ -481,13 +481,13 @@
                               P_x_lo
                               P_y_hi
                               P_y_lo
-                              P_x_square_hi
-                              P_x_square_lo
+                              P_y_square_hi
+                              P_y_square_lo
                               P_x_cube_plus_three_hi
                               P_x_cube_plus_three_lo)
   (begin (callToLT k P_x_hi P_x_lo P_BN_HI P_BN_LO)
          (callToLT (+ k 1) P_y_hi P_y_lo P_BN_HI P_BN_LO)
-         (callToEQ (+ k 2) P_x_square_hi P_x_square_lo P_x_cube_plus_three_hi P_x_cube_plus_three_lo)))
+         (callToEQ (+ k 2) P_y_square_hi P_y_square_lo P_x_cube_plus_three_hi P_x_cube_plus_three_lo)))
 
 ;; Note: in the specs for simplicity we omit the last four arguments
 (defun (callToC1MembershipEXT k

--- a/ecdata/constraints.lisp
+++ b/ecdata/constraints.lisp
@@ -487,7 +487,7 @@
                               P_x_cube_plus_three_lo)
   (begin (callToLT k P_x_hi P_x_lo P_BN_HI P_BN_LO)
          (callToLT (+ k 1) P_y_hi P_y_lo P_BN_HI P_BN_LO)
-         (callToEQ (+ k 2) P_y_square_hi P_y_square_lo P_x_cube_plus_three_hi P_x_cube_plus_three_lo)))
+         (callToEQ (+ k 2) P_x_square_hi P_x_square_lo P_x_cube_plus_three_hi P_x_cube_plus_three_lo)))
 
 ;; Note: in the specs for simplicity we omit the last four arguments
 (defun (callToC1MembershipEXT k

--- a/hub/columns/stack.lisp
+++ b/hub/columns/stack.lisp
@@ -74,10 +74,5 @@
    ( HASH_INFO_KECCAK_LO     :i128 )
 
    ;; log info related
-   (LOG_INFO_FLAG :binary@prove)
-   )
-
-  (defalias
-   INST    INSTRUCTION
-   ))
+   (LOG_INFO_FLAG :binary@prove)))
 

--- a/hub/constraints/account.lisp
+++ b/hub/constraints/account.lisp
@@ -9,58 +9,58 @@
 ;; Nonce constraintes
 
 (defun (same_nonce_h)
- (eq! NONCE NONCE_NEW))
+ (eq! account/NONCE account/NONCE_NEW))
 
 (defun (increment_nonce_h)
- (eq! NONCE_NEW (+ NONCE 1)))
+ (eq! account/NONCE_NEW (+ account/NONCE 1)))
 
 (defun (decrement_nonce_h)
- (eq! NONCE_NEW (- NONCE 1)))
+ (eq! account/NONCE_NEW (- account/NONCE 1)))
 
 (defun (undo_account_nonce_update_v)
  (begin
-  (eq! NONCE (- (prev NONCE_NEW) 1))
-  (eq! NONCE_NEW (prev NONCE))))
+  (eq! account/NONCE (- (prev account/NONCE_NEW) 1))
+  (eq! account/NONCE_NEW (prev account/NONCE))))
 
 (defun (undo_previous_account_nonce_update_v)
  (begin
-  (eq! NONCE (- (shift NONCE_NEW -2) 1))
-  (eq! NONCE_NEW (shift NONCE -2))))
+  (eq! account/NONCE (- (shift account/NONCE_NEW -2) 1))
+  (eq! account/NONCE_NEW (shift account/NONCE -2))))
 
 ;; Balance constraints
 (defun (same_balance_h)
- (eq! BALANCE_NEW BALANCE))
+ (eq! account/BALANCE_NEW account/BALANCE))
 
 (defun (undo_account_balance_update_v)
  (begin
-  (eq! BALANCE (prev BALANCE_NEW))
-  (eq! BALANCE_NEW (prev BALANCE))))
+  (eq! account/BALANCE (prev account/BALANCE_NEW))
+  (eq! account/BALANCE_NEW (prev account/BALANCE))))
 
 (defun (undo_previous_account_balance_update_v)
  (begin
-  (eq! BALANCE (shift BALANCE_NEW -2))
-  (eq! BALANCE_NEW (shift BALANCE -2))))
+  (eq! account/BALANCE (shift account/BALANCE_NEW -2))
+  (eq! account/BALANCE_NEW (shift account/BALANCE -2))))
 
 ;; Warmth constraints
 (defun (same_account_warmth_h)
- (eq! WARMTH_NEW WARMTH))
+ (eq! account/WARMTH_NEW account/WARMTH))
 
 (defun (turn_on_account_warmth_h)
- (eq! WARMTH_NEW 1))
+ (eq! account/WARMTH_NEW 1))
 
 (defun (undo_account_warmth_update_v)
  (begin
-  (eq! WARMTH (prev WARMTH_NEW))
-  (eq! WARMTH_NEW (prev WARMTH))))
+  (eq! account/WARMTH (prev account/WARMTH_NEW))
+  (eq! account/WARMTH_NEW (prev account/WARMTH))))
 
 ;; Code constraints
 (defun (same_code_size_h)
- (eq! CODE_SIZE_NEW CODE_SIZE))
+ (eq! account/CODE_SIZE_NEW account/CODE_SIZE))
 
 (defun (same_code_hash_h)
  (begin
-  (eq! CODE_HASH_HI_NEW CODE_HASH_HI)
-  (eq! CODE_HASH_LO_NEW CODE_HASH_LO)))
+  (eq! account/CODE_HASH_HI_NEW account/CODE_HASH_HI)
+  (eq! account/CODE_HASH_LO_NEW account/CODE_HASH_LO)))
 
 (defun (same_code_h)
  (begin
@@ -69,22 +69,22 @@
 
 (defun (undo_code_size_update_v)
  (begin
-  (eq! CODE_SIZE (prev CODE_SIZE_NEW))
-  (eq! CODE_SIZE_NEW (prev CODE_SIZE))))
+  (eq! account/CODE_SIZE (prev account/CODE_SIZE_NEW))
+  (eq! account/CODE_SIZE_NEW (prev account/CODE_SIZE))))
 
 (defun (undo_code_hash_update_v)
  (begin
-  (eq! CODE_HASH_HI (prev CODE_HASH_HI_NEW))
-  (eq! CODE_HASH_HI_NEW (prev CODE_HASH_HI))
-  (eq! CODE_HASH_LO (prev CODE_HASH_LO_NEW))
-  (eq! CODE_HASH_LO_NEW (prev CODE_HASH_LO))))
+  (eq! account/CODE_HASH_HI (prev account/CODE_HASH_HI_NEW))
+  (eq! account/CODE_HASH_HI_NEW (prev account/CODE_HASH_HI))
+  (eq! account/CODE_HASH_LO (prev account/CODE_HASH_LO_NEW))
+  (eq! account/CODE_HASH_LO_NEW (prev account/CODE_HASH_LO))))
 
 ;; Deployment status constraints
 (defun (same_dep_number_h)
- (eq! DEPLOYMENT_NUMBER_NEW DEPLOYMENT_NUMBER))
+ (eq! account/DEPLOYMENT_NUMBER_NEW account/DEPLOYMENT_NUMBER))
 
 (defun (same_dep_status_h)
- (eq! DEPLOYMENT_STATUS_NEW DEPLOYMENT_STATUS))
+ (eq! account/DEPLOYMENT_STATUS_NEW account/DEPLOYMENT_STATUS))
 
 (defun (same_dep_num_and_status_h)
  (begin
@@ -93,13 +93,13 @@
 
 (defun (undo_dep_number_update_v)
  (begin
-  (eq! DEPLOYMENT_NUMBER (prev DEPLOYMENT_NUMBER_NEW))
-  (eq! DEPLOYMENT_NUMBER_NEW (prev DEPLOYMENT_NUMBER))))
+  (eq! account/DEPLOYMENT_NUMBER (prev account/DEPLOYMENT_NUMBER_NEW))
+  (eq! account/DEPLOYMENT_NUMBER_NEW (prev account/DEPLOYMENT_NUMBER))))
 
 (defun (undo_dep_status_update_v)
  (begin
-  (eq! DEPLOYMENT_STATUS (prev DEPLOYMENT_STATUS_NEW))
-  (eq! DEPLOYMENT_STATUS_NEW (prev DEPLOYMENT_STATUS))))
+  (eq! account/DEPLOYMENT_STATUS (prev account/DEPLOYMENT_STATUS_NEW))
+  (eq! account/DEPLOYMENT_STATUS_NEW (prev account/DEPLOYMENT_STATUS))))
 
 (defun (undo_dep_status_and_number_update_v)
  (begin
@@ -107,34 +107,34 @@
   (undo_dep_status_update_v)))
 
 (defun (increment_dep_number_h)
- (eq! DEPLOYMENT_NUMBER_NEW (+ DEPLOYMENT_NUMBER 1)))
+ (eq! account/DEPLOYMENT_NUMBER_NEW (+ account/DEPLOYMENT_NUMBER 1)))
 
 (defun (fresh_new_dep_num_and_status_h)
  (begin
-  (vanishes! NONCE_NEW)
-  (vanishes CODE_SIZE_NEW)
-  (vanishes! HAS_CODE_NEW)
-  (debug (eq! CODE_HASH_HI_NEW    EMPTY_KECCAK_HI))
-  (debug (eq! CODE_HASH_LO_NEW    EMPTY_KECCAK_LO))
+  (vanishes! account/NONCE_NEW)
+  (vanishes! account/CODE_SIZE_NEW)
+  (vanishes! account/HAS_CODE_NEW)
+  (debug (eq! account/CODE_HASH_HI_NEW    EMPTY_KECCAK_HI))
+  (debug (eq! account/CODE_HASH_LO_NEW    EMPTY_KECCAK_LO))
   (increment_dep_number_h)
-  (vanishes! DEPLOYMENT_STATUS_NEW)))
+  (vanishes! account/DEPLOYMENT_STATUS_NEW)))
 
 (defun (dep_num_and_status_update_for_deployment_with_code_h)
  (begin
   (increment_dep_number_h)
-  (eq! DEPLOYMENT_STATUS_NEW 1)
-  (vanishes! HAS_CODE_NEW)
-  (debug (eq! CODE_HASH_HI_NEW    EMPTY_KECCAK_HI))
-  (debug (eq! CODE_HASH_LO_NEW    EMPTY_KECCAK_LO))))
+  (eq! account/DEPLOYMENT_STATUS_NEW 1)
+  (vanishes! account/HAS_CODE_NEW)
+  (debug (eq! account/CODE_HASH_HI_NEW    EMPTY_KECCAK_HI))
+  (debug (eq! account/CODE_HASH_LO_NEW    EMPTY_KECCAK_LO))))
 
 (defun (dep_num_and_status_update_for_deployment_without_code_h)
  (begin
   (increment_dep_number_h)
-  (vanishes! DEPLOYMENT_STATUS_NEW)
-  (vanishes! CODE_SIZE_NEW)
-  (vanishes HAS_CODE_NEW)
-  (debug (eq! CODE_HASH_HI_NEW    EMPTY_KECCAK_HI))
-  (debug (eq! CODE_HASH_LO_NEW    EMPTY_KECCAK_LO))))
+  (vanishes! account/DEPLOYMENT_STATUS_NEW)
+  (vanishes! account/CODE_SIZE_NEW)
+  (vanishes! account/HAS_CODE_NEW)
+  (debug (eq! account/CODE_HASH_HI_NEW    EMPTY_KECCAK_HI))
+  (debug (eq! account/CODE_HASH_LO_NEW    EMPTY_KECCAK_LO))))
 
 ;; Account inspection
 (defun (account_opening_h)
@@ -150,40 +150,40 @@
 
 (defun (account_deletion_h)
  (begin
-  (vanishes! NONCE_NEW)
-  (vanishes! BALANCE_NEW)
-  (vanishes! CODE_SIZE_NEW)
-  (vanishes! HAS_CODE_NEW)
-  (debug (eq! CODE_HASH_HI_NEW    EMPTY_KECCAK_HI))
-  (debug (eq! CODE_HASH_LO_NEW    EMPTY_KECCAK_LO))
-  fresh_new_dep_num_and_status_h))
+  (vanishes! account/NONCE_NEW)
+  (vanishes! account/BALANCE_NEW)
+  (vanishes! account/CODE_SIZE_NEW)
+  (vanishes! account/HAS_CODE_NEW)
+  (debug (eq! account/CODE_HASH_HI_NEW    EMPTY_KECCAK_HI))
+  (debug (eq! account/CODE_HASH_LO_NEW    EMPTY_KECCAK_LO))
+  (fresh_new_dep_num_and_status_h)))
 
 (defun (same_addr_as_previously_v)
  (begin
-  (remained-constant! ADDRESS_HI)
-  (remained-constant! ADDRESS_LO)))
+  (remained-constant! account/ADDRESS_HI)
+  (remained-constant! account/ADDRESS_LO)))
 
 (defun (same_addr_and_dep_num_as_previously_v)
  (begin
   (same_addr_as_previously_v)
-  (eq! DEPLOYMENT_NUMBER (prev DEPLOYMENT_NUMBER_NEW))))
+  (eq! account/DEPLOYMENT_NUMBER (prev account/DEPLOYMENT_NUMBER_NEW))))
 
 (defun (same_addr_and_dep_num_and_dep_stage_as_previously_v)
  (begin
   (same_addr_and_dep_num_as_previously_v)
-  (eq! DEPLOYMENT_STATUS (prev DEPLOYMENT_STATUS_NEW))))
+  (eq! account/DEPLOYMENT_STATUS (prev account/DEPLOYMENT_STATUS_NEW))))
 
-(defun (deploy_empty_bytecode_h)
- (begin
-  (eq! ADDRESS_HI CODE_ADDRESS_HI)
-  (eq! ADDRESS_LO CODE_ADDRESS_LO)
-  (eq! DEPLOYMENT_NUMBER CODE_DEPLOYMENT_NUMBER)
-  (debug (eq! DEPLOYMENT_STATUS 1))
-  (debug (vanishes! DEPLOYMENT_STATUS_NEW))
-  (eq! DEPLOYMENT_STATUS_NEW (- DEPLOYMENT_STATUS 1))
-  (vanishes! CODE_SIZE_NEW)
-  (vanishes! HAS_CODE_NEW)
-  (debug same_code_hash_h)))
+;; (defun (deploy_empty_bytecode_h)
+;;  (begin
+;;   (eq! account/ADDRESS_HI CODE_ADDRESS_HI)
+;;   (eq! account/ADDRESS_LO CODE_ADDRESS_LO)
+;;   (eq! account/DEPLOYMENT_NUMBER CODE_DEPLOYMENT_NUMBER)
+;;   (debug (eq! account/DEPLOYMENT_STATUS 1))
+;;   (debug (vanishes! account/DEPLOYMENT_STATUS_NEW))
+;;   (eq! account/DEPLOYMENT_STATUS_NEW (- account/DEPLOYMENT_STATUS 1))
+;;   (vanishes! account/CODE_SIZE_NEW)
+;;   (vanishes! account/HAS_CODE_NEW)
+;;   (debug same_code_hash_h)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -193,18 +193,18 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defconstraint hascode_emptyness (:perspective account)
- (if-eq-else CODE_HASH_HI EMPTY_KECCAK_HI
-    (if-eq-else CODE_HASH_LO EMPTY_KECCAK_LO
+ (if-eq-else account/CODE_HASH_HI EMPTY_KECCAK_HI
+    (if-eq-else account/CODE_HASH_LO EMPTY_KECCAK_LO
         (vanishes! HAS_CODE)
         (eq! HAS_CODE 1))
     (eq! HAS_CODE 1)))
 
 (defconstraint hascode_new_emptyness (:perspective account)
-               (if-eq-else    CODE_HASH_HI_NEW    EMPTY_KECCAK_HI
-                              (if-eq-else    CODE_HASH_LO_NEW    EMPTY_KECCAK_LO
-                                             (eq!    HAS_CODE_NEW 0)
-                                             (eq!    HAS_CODE_NEW 1))
-                              (eq!    HAS_CODE_NEW    1)))
+               (if-eq-else    account/CODE_HASH_HI_NEW    EMPTY_KECCAK_HI
+                              (if-eq-else    account/CODE_HASH_LO_NEW    EMPTY_KECCAK_LO
+                                             (eq!    account/HAS_CODE_NEW 0)
+                                             (eq!    account/HAS_CODE_NEW 1))
+                              (eq!    account/HAS_CODE_NEW    1)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -220,11 +220,11 @@
   (is-binary EXISTS_NEW)))
 
 (defconstraint exists_is_on (:perspective account)
- (if-zero (+ (~ NONCE) (~ BALANCE) (~ HAS_CODE))
+ (if-zero (+ (~ account/NONCE) (~ account/BALANCE) (~ HAS_CODE))
     (vanishes! EXISTS)
     (eq! EXISTS 1)))
 
 (defconstraint exists_new_is_on (:perspective account)
- (if-zero (+ (~ NONCE_NEW) (~ BALANCE_NEW) (~ HAS_CODE_NEW))
+ (if-zero (+ (~ account/NONCE_NEW) (~ account/BALANCE_NEW) (~ account/HAS_CODE_NEW))
     (vanishes! EXISTS_NEW)
     (eq! EXISTS_NEW 1)))

--- a/hub/constraints/account.lisp
+++ b/hub/constraints/account.lisp
@@ -195,9 +195,9 @@
 (defconstraint hascode_emptyness (:perspective account)
  (if-eq-else account/CODE_HASH_HI EMPTY_KECCAK_HI
     (if-eq-else account/CODE_HASH_LO EMPTY_KECCAK_LO
-        (vanishes! HAS_CODE)
-        (eq! HAS_CODE 1))
-    (eq! HAS_CODE 1)))
+        (vanishes! account/HAS_CODE)
+        (eq!       account/HAS_CODE 1))
+    (eq! account/HAS_CODE 1)))
 
 (defconstraint hascode_new_emptyness (:perspective account)
                (if-eq-else    account/CODE_HASH_HI_NEW    EMPTY_KECCAK_HI
@@ -216,8 +216,8 @@
 ;; TODO DEBUG Only
 (defconstraint exist_is_binary (:perspective account)
  (begin
-  (is-binary EXISTS)
-  (is-binary EXISTS_NEW)))
+  (is-binary account/EXISTS)
+  (is-binary account/EXISTS_NEW)))
 
 (defconstraint exists_is_on (:perspective account)
  (if-zero (+ (~ account/NONCE) (~ account/BALANCE) (~ account/HAS_CODE))

--- a/hub/constraints/account.lisp
+++ b/hub/constraints/account.lisp
@@ -19,13 +19,13 @@
 
 (defun (undo_account_nonce_update_v)
  (begin
-  (eq! account/NONCE (- (prev account/NONCE_NEW) 1))
+  (eq! account/NONCE  (- (prev account/NONCE_NEW) 1))
   (eq! account/NONCE_NEW (prev account/NONCE))))
 
 (defun (undo_previous_account_nonce_update_v)
  (begin
-  (eq! account/NONCE (- (shift account/NONCE_NEW -2) 1))
-  (eq! account/NONCE_NEW (shift account/NONCE -2))))
+  (eq! account/NONCE  (- (shift account/NONCE_NEW -2) 1))
+  (eq! account/NONCE_NEW (shift account/NONCE     -2))))
 
 ;; Balance constraints
 (defun (same_balance_h)
@@ -38,8 +38,8 @@
 
 (defun (undo_previous_account_balance_update_v)
  (begin
-  (eq! account/BALANCE (shift account/BALANCE_NEW -2))
-  (eq! account/BALANCE_NEW (shift account/BALANCE -2))))
+  (eq! account/BALANCE     (shift account/BALANCE_NEW -2))
+  (eq! account/BALANCE_NEW (shift account/BALANCE     -2))))
 
 ;; Warmth constraints
 (defun (same_account_warmth_h)
@@ -50,7 +50,7 @@
 
 (defun (undo_account_warmth_update_v)
  (begin
-  (eq! account/WARMTH (prev account/WARMTH_NEW))
+  (eq! account/WARMTH     (prev account/WARMTH_NEW))
   (eq! account/WARMTH_NEW (prev account/WARMTH))))
 
 ;; Code constraints
@@ -69,14 +69,14 @@
 
 (defun (undo_code_size_update_v)
  (begin
-  (eq! account/CODE_SIZE (prev account/CODE_SIZE_NEW))
+  (eq! account/CODE_SIZE     (prev account/CODE_SIZE_NEW))
   (eq! account/CODE_SIZE_NEW (prev account/CODE_SIZE))))
 
 (defun (undo_code_hash_update_v)
  (begin
-  (eq! account/CODE_HASH_HI (prev account/CODE_HASH_HI_NEW))
+  (eq! account/CODE_HASH_HI     (prev account/CODE_HASH_HI_NEW))
   (eq! account/CODE_HASH_HI_NEW (prev account/CODE_HASH_HI))
-  (eq! account/CODE_HASH_LO (prev account/CODE_HASH_LO_NEW))
+  (eq! account/CODE_HASH_LO     (prev account/CODE_HASH_LO_NEW))
   (eq! account/CODE_HASH_LO_NEW (prev account/CODE_HASH_LO))))
 
 ;; Deployment status constraints
@@ -93,12 +93,12 @@
 
 (defun (undo_dep_number_update_v)
  (begin
-  (eq! account/DEPLOYMENT_NUMBER (prev account/DEPLOYMENT_NUMBER_NEW))
+  (eq! account/DEPLOYMENT_NUMBER     (prev account/DEPLOYMENT_NUMBER_NEW))
   (eq! account/DEPLOYMENT_NUMBER_NEW (prev account/DEPLOYMENT_NUMBER))))
 
 (defun (undo_dep_status_update_v)
  (begin
-  (eq! account/DEPLOYMENT_STATUS (prev account/DEPLOYMENT_STATUS_NEW))
+  (eq! account/DEPLOYMENT_STATUS     (prev account/DEPLOYMENT_STATUS_NEW))
   (eq! account/DEPLOYMENT_STATUS_NEW (prev account/DEPLOYMENT_STATUS))))
 
 (defun (undo_dep_status_and_number_update_v)
@@ -220,11 +220,11 @@
   (is-binary EXISTS_NEW)))
 
 (defconstraint exists_is_on (:perspective account)
- (if-zero (+ (~ account/NONCE) (~ account/BALANCE) (~ HAS_CODE))
-    (vanishes! EXISTS)
-    (eq! EXISTS 1)))
+ (if-zero (+ (~ account/NONCE) (~ account/BALANCE) (~ account/HAS_CODE))
+    (vanishes! account/EXISTS)
+    (eq!       account/EXISTS 1)))
 
 (defconstraint exists_new_is_on (:perspective account)
  (if-zero (+ (~ account/NONCE_NEW) (~ account/BALANCE_NEW) (~ account/HAS_CODE_NEW))
-    (vanishes! EXISTS_NEW)
-    (eq! EXISTS_NEW 1)))
+    (vanishes! account/EXISTS_NEW)
+    (eq!       account/EXISTS_NEW 1)))

--- a/hub/constraints/instruction-handling/call/generalities/universal.lisp
+++ b/hub/constraints/instruction-handling/call/generalities/universal.lisp
@@ -149,7 +149,7 @@
                                       (eq!                (+    scenario/CALL_SMC_FAILURE_CALLER_WILL_REVERT    scenario/CALL_SMC_SUCCESS_CALLER_WILL_REVERT)
                                                           (call-instruction---caller-will-revert))
                                       (debug    (eq!      (+    scenario/CALL_SMC_FAILURE_CALLER_WONT_REVERT    scenario/CALL_SMC_SUCCESS_CALLER_WONT_REVERT)
-                                                          (-    1    call-instruction---caller-will-revert)))
+                                                          (-    1    (call-instruction---caller-will-revert))))
                                       (eq!                (scenario-shorthand---CALL---smc-failure)               (call-instruction---callee-self-reverts))
                                       (eq!                (scenario-shorthand---CALL---smc-success)    (-    1    (call-instruction---callee-self-reverts)))))))
 

--- a/hub/constraints/instruction-handling/call/triggers.lisp
+++ b/hub/constraints/instruction-handling/call/triggers.lisp
@@ -30,7 +30,7 @@
 
 (defun    (call-instruction---trigger_ROMLEX)                        (+    (scenario-shorthand---CALL---smart-contract)))
 
-(defun    (call-instruction---call-requires-callee-account)          (+    (shift    misc/STP_FLAG    CALL_misc___row_offset)))
+;; (defun    (call-instruction---call-requires-callee-account)          (+    (shift    misc/STP_FLAG    CALL_misc___row_offset)))
 
 (defun    (call-instruction---call-requires-caller-account)          (+    (scenario-shorthand---CALL---unexceptional)))
 

--- a/hub/constraints/instruction-handling/halting/selfdestruct.lisp
+++ b/hub/constraints/instruction-handling/halting/selfdestruct.lisp
@@ -280,7 +280,7 @@
                                    (if-eq-else (selfdestruct-instruction---account-address) (selfdestruct-instruction---recipient-address)
                                                ;; self destructing account address = recipient address
                                                (begin
-                                                 (debug (vanishes! account/BALANCE     ROFF_SELFDESTRUCT___ACCOUNT___2ND_DOING_ROW))
+                                                 ;;(debug (vanishes! account/BALANCE     ROFF_SELFDESTRUCT___ACCOUNT___2ND_DOING_ROW))
                                                  (account-same-balance                 ROFF_SELFDESTRUCT___ACCOUNT___2ND_DOING_ROW))
                                                ;; self destructing account address ≠ recipient address
                                                (account-increment-balance-by           ROFF_SELFDESTRUCT___ACCOUNT___2ND_DOING_ROW    (selfdestruct-instruction---balance)))))))

--- a/hub/constraints/stack_patterns.lisp
+++ b/hub/constraints/stack_patterns.lisp
@@ -292,10 +292,10 @@
 ;;                                                ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defun  (b-sum-1) (+ b1 b2 b3 b4))
-(defun  (b-sum-2) (+    b2 b3 b4))
-(defun  (b-sum-3) (+       b3 b4))
-(defun  (b-sum-4)             b4 )
+(defun  (b-sum-1 b1 b2 b3 b4) (+ b1 b2 b3 b4))
+(defun  (b-sum-2 b2 b3 b4) (+    b2 b3 b4))
+(defun  (b-sum-3 b3 b4) (+       b3 b4))
+(defun  (b-sum-4 b4)             b4 )
 
 (defun (log-stack-pattern param (b1 :binary) (b2 :binary) (b3 :binary) (b4 :binary))
                 (begin
@@ -314,21 +314,21 @@
                     ;; height update;
                     (debug (=  HEIGHT_NEW  (- HEIGHT  param 2)))
                     ;; stack item 5:
-                    (will-eq! [ stack/STACK_ITEM_HEIGHT 1 ]       (* (b-sum-1) (- HEIGHT 2)))
-                    (will-eq! [ stack/STACK_ITEM_POP    1 ]          (b-sum-1))
-                    (will-eq! [ stack/STACK_ITEM_STAMP  1 ]       (* (b-sum-1) (+ (* MULTIPLIER___STACK_STAMP HUB_STAMP) 2)))
+                    (will-eq! [ stack/STACK_ITEM_HEIGHT 1 ]       (* (b-sum-1 b1 b2 b3 b4) (- HEIGHT 2)))
+                    (will-eq! [ stack/STACK_ITEM_POP    1 ]          (b-sum-1 b1 b2 b3 b4))
+                    (will-eq! [ stack/STACK_ITEM_STAMP  1 ]       (* (b-sum-1 b1 b2 b3 b4) (+ (* MULTIPLIER___STACK_STAMP HUB_STAMP) 2)))
                     ;; stack item 6:
-                    (will-eq! [ stack/STACK_ITEM_HEIGHT 2 ]       (* (b-sum-2) (- HEIGHT 3)))
-                    (will-eq! [ stack/STACK_ITEM_POP    2 ]          (b-sum-2))
-                    (will-eq! [ stack/STACK_ITEM_STAMP  2 ]       (* (b-sum-2) (+ (* MULTIPLIER___STACK_STAMP HUB_STAMP) 3)))
+                    (will-eq! [ stack/STACK_ITEM_HEIGHT 2 ]       (* (b-sum-2 b2 b3 b4) (- HEIGHT 3)))
+                    (will-eq! [ stack/STACK_ITEM_POP    2 ]          (b-sum-2 b2 b3 b4))
+                    (will-eq! [ stack/STACK_ITEM_STAMP  2 ]       (* (b-sum-2 b2 b3 b4) (+ (* MULTIPLIER___STACK_STAMP HUB_STAMP) 3)))
                     ;; stack item 7:
-                    (will-eq! [ stack/STACK_ITEM_HEIGHT 3 ]       (* (b-sum-3) (- HEIGHT 4)))
-                    (will-eq! [ stack/STACK_ITEM_POP    3 ]          (b-sum-3))
-                    (will-eq! [ stack/STACK_ITEM_STAMP  3 ]       (* (b-sum-3) (+ (* MULTIPLIER___STACK_STAMP HUB_STAMP) 4)))
+                    (will-eq! [ stack/STACK_ITEM_HEIGHT 3 ]       (* (b-sum-3 b3 b4) (- HEIGHT 4)))
+                    (will-eq! [ stack/STACK_ITEM_POP    3 ]          (b-sum-3 b3 b4))
+                    (will-eq! [ stack/STACK_ITEM_STAMP  3 ]       (* (b-sum-3 b3 b4) (+ (* MULTIPLIER___STACK_STAMP HUB_STAMP) 4)))
                     ;; stack item 8:
-                    (will-eq! [ stack/STACK_ITEM_HEIGHT 4 ]       (* (b-sum-4) (- HEIGHT 5)))
-                    (will-eq! [ stack/STACK_ITEM_POP    4 ]          (b-sum-4))
-                    (will-eq! [ stack/STACK_ITEM_STAMP  4 ]       (* (b-sum-4) (+ (* MULTIPLIER___STACK_STAMP HUB_STAMP) 5)))))
+                    (will-eq! [ stack/STACK_ITEM_HEIGHT 4 ]       (* (b-sum-4 b4) (- HEIGHT 5)))
+                    (will-eq! [ stack/STACK_ITEM_POP    4 ]          (b-sum-4 b4))
+                    (will-eq! [ stack/STACK_ITEM_STAMP  4 ]       (* (b-sum-4 b4) (+ (* MULTIPLIER___STACK_STAMP HUB_STAMP) 5)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                            ;;

--- a/hub/lookups/hub_into_rom_instruction_fetching.lisp
+++ b/hub/lookups/hub_into_rom_instruction_fetching.lisp
@@ -1,4 +1,4 @@
-(defpurefun (hub-into-rom-instruction-fetching-trigger) hub.PEEK_AT_STACK)
+(defun (hub-into-rom-instruction-fetching-trigger) hub.PEEK_AT_STACK)
 
 (deflookup hub-into-rom-instruction-fetching
            ;; target columns

--- a/logdata/lookups/logdata-to-rlprcpt.lisp
+++ b/logdata/lookups/logdata-to-rlprcpt.lisp
@@ -1,4 +1,4 @@
-(defpurefun (sel-logdata-to-rlptxnrcpt)
+(defun (sel-logdata-to-rlptxnrcpt)
   logdata.LOGS_DATA)
 
 (deflookup

--- a/loginfo/lookups/loginfo-into-logdata.lisp
+++ b/loginfo/lookups/loginfo-into-logdata.lisp
@@ -1,4 +1,4 @@
-(defpurefun (sel-loginfo-to-logdata)
+(defun (sel-loginfo-to-logdata)
   loginfo.TXN_EMITS_LOGS)
 
 (deflookup

--- a/rlptxn/constraints.lisp
+++ b/rlptxn/constraints.lisp
@@ -253,13 +253,13 @@
                 (if-eq IS_PHASE_VALUE 1
                        (eq! (next IS_PHASE_DATA) 1))
                 (if-eq IS_PHASE_DATA 1
-                       (begin (debug (vanishes! RLP_TXN_PHASE_SIZE))
+                       (begin ;;(debug (vanishes! RLP_TXN_PHASE_SIZE))
                               (vanishes! DATA_GAS_COST)
                               (if-zero TYPE
                                        (eq! (next IS_PHASE_BETA) 1)
                                        (eq! (next IS_PHASE_ACCESS_LIST) 1))))
                 (if-eq IS_PHASE_ACCESS_LIST 1
-                       (begin (debug (vanishes! RLP_TXN_PHASE_SIZE))
+                       (begin ;;(debug (vanishes! RLP_TXN_PHASE_SIZE))
                               (vanishes! nADDR)
                               (vanishes! nKEYS)
                               (vanishes! nKEYS_PER_ADDR)

--- a/rom/constraints.lisp
+++ b/rom/constraints.lisp
@@ -60,7 +60,7 @@
                   (debug (vanishes! COUNTER_PUSH))
                   (debug (vanishes! PUSH_PARAMETER))
                   (debug (vanishes! PROGRAM_COUNTER)))
-           (begin (debug (or! (eq! COUNTER_MAX LLARGEMO) (eq! COUNTER_MAX EVMWORDMO)))
+           (begin (debug (or! (eq! COUNTER_MAX LLARGEMO) (eq! COUNTER_MAX WORD_SIZE_MO)))
                   (if-eq COUNTER_MAX LLARGEMO (will-remain-constant! CFI))
                   (if-not-eq COUNTER COUNTER_MAX (will-remain-constant! CFI))
                   (if-eq CT WORD_SIZE_MO (will-inc! CFI 1)))))

--- a/shf/constraints.lisp
+++ b/shf/constraints.lisp
@@ -191,7 +191,7 @@
 ;;    2.5 shifting constraints   ;;
 ;;                               ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defun (left-shift-by k ct bit_b bit_n B1_init B2_init B1_shft B2_shft)
+(defun (left-shift-by k ct bit_b (bit_n :binary) B1_init B2_init B1_shft B2_shft)
   (begin (plateau-constraint ct bit_n (- LLARGE k))
          (if-zero bit_b
                   (begin (= B1_shft B1_init)
@@ -203,7 +203,7 @@
                                      (shift B2_init (- k LLARGE)))
                                   (vanishes! B2_shft))))))
 
-(defun (right-shift-by k ct neg inst bit_b bit_n B1_init B2_init B1_shft B2_shft)
+(defun (right-shift-by k ct neg inst bit_b (bit_n :binary) B1_init B2_init B1_shft B2_shft)
   (begin (plateau-constraint ct bit_n k)
          (if-zero bit_b
                   (begin (= B1_shft B1_init)

--- a/txndata/constraints.lisp
+++ b/txndata/constraints.lisp
@@ -131,7 +131,7 @@
                  (begin (if-zero ABS
                                  (begin (vanishes! BLK)
                                         (vanishes! REL)
-                                        (debug (vanishes! BLK_MAX))
+                                        ;;(debug (vanishes! BLK_MAX))
                                         (debug (vanishes! REL_MAX))
                                         (if-not-zero (will-remain-constant! ABS)
                                                      (begin (eq! (next BLK) 1)


### PR DESCRIPTION
This adds support for a new build target, namely `zkevm.go.bin`.  This target is built using `go-corset` rather than the original `corset` tool.  In order to make this work, a very small number of fixes to the constraints were required.  These consist of simple typos and/or broken debug constraints.