### PR TITLE
Replace `NEGATIVE_OF_BLOCKHASH` with a `(defun ...)` expression

### DIFF
--- a/blockhash/constants.lisp
+++ b/blockhash/constants.lisp
@@ -4,7 +4,6 @@
   nROWS_MACRO                                                              1
   nROWS_PRPRC                                                              5
   BLOCKHASH_DEPTH                                (+ nROWS_MACRO nROWS_PRPRC)
-  NEGATIVE_OF_BLOCKHASH_DEPTH                          (- 0 BLOCKHASH_DEPTH)
   ROFF___BLOCKHASH_arguments___monotony                                    1
   ROFF___BLOCKHASH_arguments___equality_test                               2
   ROFF___ABS___comparison_to_256                                           3

--- a/blockhash/constraints.lisp
+++ b/blockhash/constraints.lisp
@@ -21,6 +21,7 @@
                                 (*  (-  1  PRPRC)  (next  PRPRC))))
 (defun   (ct-max-sum)       (+  (*  (-  nROWS_MACRO  1)  MACRO)
                                 (*  (-  nROWS_PRPRC  1)  PRPRC)))
+(defun   (negative-of-blockhash-depth)                          (- 0 BLOCKHASH_DEPTH))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                     ;;
@@ -105,9 +106,9 @@
 ;;                     ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defun  (not-first)                          (shift  IOMF                    NEGATIVE_OF_BLOCKHASH_DEPTH))
-(defun  (prev-BH-arg-hi)  (*   (not-first)   (shift  macro/BLOCKHASH_ARG_HI  NEGATIVE_OF_BLOCKHASH_DEPTH)))
-(defun  (prev-BH-arg-lo)  (*   (not-first)   (shift  macro/BLOCKHASH_ARG_LO  NEGATIVE_OF_BLOCKHASH_DEPTH)))
+(defun  (not-first)                          (shift  IOMF                    (negative-of-blockhash-depth)))
+(defun  (prev-BH-arg-hi)  (*   (not-first)   (shift  macro/BLOCKHASH_ARG_HI  (negative-of-blockhash-depth))))
+(defun  (prev-BH-arg-lo)  (*   (not-first)   (shift  macro/BLOCKHASH_ARG_LO  (negative-of-blockhash-depth))))
 (defun  (curr-BH-arg-hi)                             macro/BLOCKHASH_ARG_HI                       )
 (defun  (curr-BH-arg-lo)                             macro/BLOCKHASH_ARG_LO                       ) ;; ""
 
@@ -249,5 +250,5 @@
                                   (if-not-zero    (not-first)
                                                   (if-not-zero    (same-argument)
                                                                   (begin
-                                                                    (eq!   macro/BLOCKHASH_VAL_HI    (shift    macro/BLOCKHASH_VAL_HI    NEGATIVE_OF_BLOCKHASH_DEPTH))
-                                                                    (eq!   macro/BLOCKHASH_VAL_LO    (shift    macro/BLOCKHASH_VAL_LO    NEGATIVE_OF_BLOCKHASH_DEPTH)))))))
+                                                                    (eq!   macro/BLOCKHASH_VAL_HI    (shift    macro/BLOCKHASH_VAL_HI    (negative-of-blockhash-depth)))
+                                                                    (eq!   macro/BLOCKHASH_VAL_LO    (shift    macro/BLOCKHASH_VAL_LO    (negative-of-blockhash-depth))))))))


### PR DESCRIPTION
This avoids dealing with negative constants.