### PR TITLE
fix: refactor `negative-of-blockhash-depth`

### DIFF
--- a/blockhash/constraints.lisp
+++ b/blockhash/constraints.lisp
@@ -21,7 +21,7 @@
                                 (*  (-  1  PRPRC)  (next  PRPRC))))
 (defun   (ct-max-sum)       (+  (*  (-  nROWS_MACRO  1)  MACRO)
                                 (*  (-  nROWS_PRPRC  1)  PRPRC)))
-(defun   (negative-of-blockhash-depth)                          (- 0 BLOCKHASH_DEPTH))
+(defpurefun   (negative-of-blockhash-depth)                          (- 0 BLOCKHASH_DEPTH))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                     ;;


### PR DESCRIPTION
This refactors the function `negative-of-blockhash-depth` to be a `defpurefun` instead of simply a `defun`.