### PR TITLE
feat: swap `corset` for `go-corset` on CI build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,22 +10,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    # The asset URL for the latest release can be found with:
-    # curl -L -H "Accept: application/vnd.github+json"  \
-    #     -H "Authorization: Bearer YOUR_GH_API_TOKEN" \
-    #     -H "X-GitHub-Api-Version: 2022-11-28" \
-    #     https://api.github.com/repos/ConsenSys/corset/releases/latest
-    # | jq '.assets[] | select(.name|endswith("x86_64-unknown-linux-musl.tar.gz")) | .url'
-    - name: Download Corset
-      run: |
-        curl -L \
-        -H "Accept: application/octet-stream" \
-        -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        -o corset.tar.gz \
-        https://api.github.com/repos/Consensys/corset/releases/assets/203897668
-        tar xzf corset.tar.gz
-        mv corset $HOME
+    - name: Install Go
+      uses: actions/setup-go@v5.1.0
 
-    - name: Build the constraint system
-      run: CORSET=$HOME/corset make -B zkevm.bin
+    - name: Install Go Corset
+      shell: bash
+      run: go install github.com/consensys/go-corset/cmd/go-corset@latest
+
+    - name: Build Constraints
+      run: make -B zkevm.go.bin


### PR DESCRIPTION
This swaps out the Rust `corset` tool for the new `go-corset` tool in the CI build.  This will help to ensure that the constraints always compile with `go-corset`.