### PR TITLE
 Fix typos and remove duplicate header

### DIFF
--- a/hub/constraints/context-rows/specialized.lisp
+++ b/hub/constraints/context-rows/specialized.lisp
@@ -18,13 +18,6 @@
   (eq! CONTEXT_NUMBER_NEW
        CALLER_CONTEXT_NUMBER))
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;                                         ;;
-;;   6.1 Setting the next context number   ;;
-;;                                         ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 (defun (initialize-context
          relative_row_offset                   ;; row offset
          cn                                    ;; context number

--- a/library/rlp_constraints_pattern.lisp
+++ b/library/rlp_constraints_pattern.lisp
@@ -1,4 +1,4 @@
-;;  Comparaison to 55 ;;
+;;  Comparison to 55 ;;
 (defpurefun (compTo55 length comp acc)
   (eq! acc
        (- (* (- (* 2 comp) 1)


### PR DESCRIPTION


1. Removed duplicate section header "6.1 Setting the next context number" in hub/constraints/context-rows/specialized.lisp
2. Fixed typo in library/rip_constraints_pattern.lisp: "Comparaison" -> "Comparison"

These changes improve code readability and maintain consistent English spelling throughout the codebase.

Files changed:
- hub/constraints/context-rows/specialized.lisp
- library/rip_constraints_pattern.lisp