### PR TITLE
fix: fix incorrect CODESIZE_REACHED update logic

### DIFF
--- a/rom/constraints.lisp
+++ b/rom/constraints.lisp
@@ -92,8 +92,7 @@
 ;; CODESIZE_REACHED Constraints
 (defconstraint codesizereached-trigger ()
   (if-eq PC (- CODE_SIZE 1)
-         (eq! (+ CODESIZE_REACHED (next CODESIZE_REACHED))
-              1)))
+         (eq! (next CODESIZE_REACHED) (+ CODESIZE_REACHED 1))))
 
 (defconstraint csr-impose-ctmax (:guard CFI)
   (if-zero CT


### PR DESCRIPTION
Noticed an issue in the CODESIZE_REACHED increment logic—(eq! (+ CODESIZE_REACHED (next CODESIZE_REACHED)) 1) was likely incorrect. The proper check should be (eq! (next CODESIZE_REACHED) (+ CODESIZE_REACHED 1)), ensuring that (next CODESIZE_REACHED) increments by 1 instead of summing with the current value.  

This could have caused logical issues in verifying CODESIZE_REACHED updates. Fixed it to reflect the intended behavior.