### PR TITLE
Reintroduce `acp_EXISTS` / `acp_EXISTS_NEW` columns for state manager

### DIFF
--- a/hub/constraints/consistency/account/columns.lisp
+++ b/hub/constraints/consistency/account/columns.lisp
@@ -31,6 +31,8 @@
       acp_CODE_HASH_LO_NEW
       acp_CODE_SIZE
       acp_CODE_SIZE_NEW
+      acp_EXISTS
+      acp_EXISTS_NEW
       acp_WARMTH
       acp_WARMTH_NEW
       acp_DEPLOYMENT_NUMBER
@@ -64,6 +66,8 @@
       account/CODE_HASH_LO_NEW
       account/CODE_SIZE
       account/CODE_SIZE_NEW
+      account/EXISTS
+      account/EXISTS_NEW
       account/WARMTH
       account/WARMTH_NEW
       account/DEPLOYMENT_NUMBER

--- a/hub/constraints/consistency/account/constraints.lisp
+++ b/hub/constraints/consistency/account/constraints.lisp
@@ -134,18 +134,21 @@
 (defconstraint    account-consistency---linking---conflation-level---balance
                   (:guard   acp_AGAIN_IN_CNF)
                   ;;;;;;;;;;;;;;;;;;;;;;;;;;;
-                  (begin
-                    (eq!   acp_BALANCE                   (prev acp_BALANCE_NEW)             )))
+                  (eq!   acp_BALANCE                   (prev acp_BALANCE_NEW)             ))
 
 (defconstraint    account-consistency---linking---conflation-level---code
                   (:guard   acp_AGAIN_IN_CNF)
                   ;;;;;;;;;;;;;;;;;;;;;;;;;;;
                   (begin
-                    (eq!   acp_CODE_SIZE                 (prev acp_CODE_SIZE_NEW)           )
-                    (eq!   acp_CODE_HASH_HI              (prev acp_CODE_HASH_HI_NEW)        )
-                    (eq!   acp_CODE_HASH_LO              (prev acp_CODE_HASH_LO_NEW)        )
-                    ;;
-                    (eq!   acp_IS_PRECOMPILE             (prev acp_IS_PRECOMPILE)           )))
+                    (eq!          acp_CODE_SIZE          (prev acp_CODE_SIZE_NEW)           )
+                    (eq!          acp_CODE_HASH_HI       (prev acp_CODE_HASH_HI_NEW)        )
+                    (eq!          acp_CODE_HASH_LO       (prev acp_CODE_HASH_LO_NEW)        )
+                    (debug (eq!   acp_EXISTS             (prev acp_EXISTS_NEW)              ))))
+
+(defconstraint    account-consistency---linking---conflation-level---precompile-status
+                  (:guard   acp_AGAIN_IN_CNF)
+                  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+                  (eq!   acp_IS_PRECOMPILE             (prev acp_IS_PRECOMPILE)           ))
 
 (defconstraint    account-consistency---linking---conflation-level---deployment-number-and-status
                   (:guard   acp_AGAIN_IN_CNF)


### PR DESCRIPTION
Implementation of https://github.com/Consensys/linea-specification/pull/97