### PR TITLE
feat: pre-step before updating to `go-corset` version `1.1`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@latest
+      run: go install github.com/consensys/go-corset/cmd/go-corset@ee34d9eb60
 
     - name: Build Constraints
       run: make -B zkevm.bin

--- a/alu/add/constraints.lisp
+++ b/alu/add/constraints.lisp
@@ -27,8 +27,8 @@
                          (debug (vanishes! CT))
                          (debug (vanishes! CT_MAX))))
          (or! (will-remain-constant! STAMP) (will-inc! STAMP 1))
-         (if-not-zero (will-remain-constant! STAMP)
-                      (vanishes! (next CT)))
+         (if-not (will-remain-constant! STAMP)
+                 (vanishes! (next CT)))
          (if-not-zero STAMP
                       (begin (or! (eq! INST EVM_INST_ADD) (eq! INST EVM_INST_SUB))
                              (if-eq-else CT CT_MAX

--- a/alu/ext/constraints.lisp
+++ b/alu/ext/constraints.lisp
@@ -18,8 +18,8 @@
                   (begin (vanishes! CT)
                          (vanishes! OLI)
                          (vanishes! INST)))
-         (if-not-zero (will-remain-constant! STAMP)
-                      (vanishes! (next CT)))
+         (if-not (will-remain-constant! STAMP)
+                 (vanishes! (next CT)))
          (if-not-zero STAMP
                       (begin (if-not-zero OLI
                                           (will-inc! STAMP 1)

--- a/alu/mod/constraints.lisp
+++ b/alu/mod/constraints.lisp
@@ -142,8 +142,8 @@
 
 (defconstraint heartbeat ()
   (begin (or! (will-remain-constant! STAMP) (will-inc! STAMP 1))
-         (if-not-zero (will-remain-constant! STAMP)
-                      (vanishes! (next CT)))
+         (if-not (will-remain-constant! STAMP)
+                 (vanishes! (next CT)))
          (if-eq OLI 1 (will-inc! STAMP 1))
          (if-eq MLI 1
                 (if-eq-else CT MMEDIUMMO (will-inc! STAMP 1) (will-inc! CT 1)))))

--- a/alu/mul/constraints.lisp
+++ b/alu/mul/constraints.lisp
@@ -38,9 +38,9 @@
                (or! (eq! INST EVM_INST_MUL) (eq! INST EVM_INST_EXP))))
 
 (defconstraint reset-stuff ()
-  (if-not-zero (will-remain-constant! STAMP)
-               (begin (vanishes! (next CT))
-                      (vanishes! (next BIT_NUM)))))
+  (if-not (will-remain-constant! STAMP)
+          (begin (vanishes! (next CT))
+                 (vanishes! (next BIT_NUM)))))
 
 (defconstraint oli-last-one-line ()
   (if-not-zero OLI
@@ -479,11 +479,11 @@
                                       (mu)))))
 
 (defun (final-square-and-multiply)
-  (if-not-zero (will-remain-constant! STAMP)
-               (begin (eq! RES_HI
-                         (+ (* THETA (C_3)) (C_2)))
-                      (eq! RES_LO
-                         (+ (* THETA (C_1)) (C_0))))))
+  (if-not (will-remain-constant! STAMP)
+          (begin (eq! RES_HI
+                     (+ (* THETA (C_3)) (C_2)))
+                 (eq! RES_LO
+                     (+ (* THETA (C_1)) (C_0))))))
 
 (defconstraint nontrivial-exp-regime-nonzero-result ()
   (if-eq INST EVM_INST_EXP

--- a/blockdata/constraints.lisp
+++ b/blockdata/constraints.lisp
@@ -57,8 +57,8 @@
                                  (vanishes! (next CT)))))
 
 (defconstraint   heartbeat---first-instruction-is-coinbase ()
-                 (if-not-zero    (will-remain-constant!    IOMF)
-                                 (will-eq!                 IS_CB 1)))
+                 (if-not    (will-remain-constant!    IOMF)
+                            (will-eq!                 IS_CB 1)))
 
 (defconstraint   heartbeat---counter-reset-at-phase-entry ()
                  (if-not-zero (phase-entry)

--- a/ecdata/constraints.lisp
+++ b/ecdata/constraints.lisp
@@ -98,7 +98,7 @@
 
 (defconstraint pair-of-points-constancy ()
   (if-not-zero ACC_PAIRINGS
-               (if-zero (will-remain-constant! ACC_PAIRINGS)
+               (if (will-remain-constant! ACC_PAIRINGS)
                    (will-remain-constant! ACCPC))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/hub/constraints/consistency/account/constraints.lisp
+++ b/hub/constraints/consistency/account/constraints.lisp
@@ -54,27 +54,27 @@
 (defconstraint    account-consistency---FIRST-AGAIN-FINAL---repeat-encounter---conflation-level
                   (:guard   (account-consistency---repeat-account-row))
                   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-                  (if-not-zero  (remained-constant! (acp_full_address))
-                                (eq! (account-consistency---transition-conflation) 2)
-                                (eq! (account-consistency---transition-conflation) 0)))
+                  (if-not  (remained-constant! (acp_full_address))
+                           (eq! (account-consistency---transition-conflation) 2)
+                           (eq! (account-consistency---transition-conflation) 0)))
 
 (defconstraint    account-consistency---FIRST-AGAIN-FINAL---repeat-encounter---block-level
                   (:guard   (account-consistency---repeat-account-row))
                   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
                   (begin
-                    (if-not-zero (remained-constant!   (acp_full_address))              (eq! (account-consistency---transition-block) 2))
-                    (if-not-zero (remained-constant!    acp_REL_BLK_NUM)                (eq! (account-consistency---transition-block) 2))
-                    (if-zero     (remained-constant!   (acp_full_address))
-                                 (if-zero    (remained-constant!    acp_REL_BLK_NUM)    (eq! (account-consistency---transition-block) 0)))))
+                    (if-not (remained-constant!   (acp_full_address))              (eq! (account-consistency---transition-block) 2))
+                    (if-not (remained-constant!    acp_REL_BLK_NUM)                (eq! (account-consistency---transition-block) 2))
+                    (if     (remained-constant!   (acp_full_address))
+                            (if    (remained-constant!    acp_REL_BLK_NUM)    (eq! (account-consistency---transition-block) 0)))))
 
 (defconstraint    account-consistency---FIRST-AGAIN-FINAL---repeat-encounter---transaction-level
                   (:guard   (account-consistency---repeat-account-row))
                   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
                   (begin
-                    (if-not-zero (remained-constant!   (acp_full_address))              (eq! (account-consistency---transition-transaction) 2))
-                    (if-not-zero (remained-constant!    acp_ABS_TX_NUM)                 (eq! (account-consistency---transition-transaction) 2))
-                    (if-zero     (remained-constant!   (acp_full_address))
-                                 (if-zero    (remained-constant!    acp_ABS_TX_NUM)     (eq! (account-consistency---transition-transaction) 0)))))
+                    (if-not (remained-constant!   (acp_full_address))              (eq! (account-consistency---transition-transaction) 2))
+                    (if-not (remained-constant!    acp_ABS_TX_NUM)                 (eq! (account-consistency---transition-transaction) 2))
+                    (if     (remained-constant!   (acp_full_address))
+                            (if    (remained-constant!    acp_ABS_TX_NUM)     (eq! (account-consistency---transition-transaction) 0)))))
 
 (defconstraint    account-consistency---FIRST-AGAIN-FINAL---final-row-with-room-to-spare ()
                   (if-not-zero (prev acp_PEEK_AT_ACCOUNT)

--- a/hub/constraints/consistency/context/constraints.lisp
+++ b/hub/constraints/consistency/context/constraints.lisp
@@ -15,9 +15,9 @@
                              (eq!    (next con_FIRST)    (next ccp_PEEK_AT_CONTEXT)))
                  (if-not-zero  ccp_PEEK_AT_CONTEXT
                                (if-not-zero (next    ccp_PEEK_AT_CONTEXT)
-                                            (if-not-zero    (will-remain-constant!   ccp_CONTEXT_NUMBER)
-                                                            (will-eq! con_FIRST 1)
-                                                            (will-eq! con_AGAIN 1))))))
+                                            (if-not    (will-remain-constant!   ccp_CONTEXT_NUMBER)
+                                                       (will-eq! con_FIRST 1)
+                                                       (will-eq! con_AGAIN 1))))))
 
 (defconstraint context-consistency---context-data-immutability ()
                (if-not-zero (next con_AGAIN)

--- a/hub/constraints/consistency/execution_environment/constraints.lisp
+++ b/hub/constraints/consistency/execution_environment/constraints.lisp
@@ -21,14 +21,14 @@
 (defconstraint execution-environment-consistency---linking ()
                (if-not-zero envcp_CN
                             (if-eq (next envcp_CN) envcp_CN
-                                   (if-not-zero (will-remain-constant! envcp_HUB_STAMP)
-                                                (begin
-                                                  (eq! (next   envcp_PC)             envcp_PC_NEW)
-                                                  (eq! (next   envcp_HEIGHT)         envcp_HEIGHT_NEW)
-                                                  (eq! (next   envcp_GAS_EXPECTED)   envcp_GAS_NEXT))))))
+                                   (if-not (will-remain-constant! envcp_HUB_STAMP)
+                                           (begin
+                                             (eq! (next   envcp_PC)             envcp_PC_NEW)
+                                             (eq! (next   envcp_HEIGHT)         envcp_HEIGHT_NEW)
+                                             (eq! (next   envcp_GAS_EXPECTED)   envcp_GAS_NEXT))))))
 
 (defconstraint execution-environment-consistency---initialization ()
-               (if-not-zero (will-remain-constant! envcp_CN)
-                            (begin
-                              (vanishes! (next envcp_PC))
-                              (vanishes! (next envcp_HEIGHT)))))
+               (if-not (will-remain-constant! envcp_CN)
+                       (begin
+                         (vanishes! (next envcp_PC))
+                         (vanishes! (next envcp_HEIGHT)))))

--- a/hub/constraints/consistency/stack/constraints.lisp
+++ b/hub/constraints/consistency/stack/constraints.lisp
@@ -19,13 +19,13 @@
                                        (next    (*    stkcp_PEEK_AT_STACK_POW_4    2))))
                     (if-not-zero    stkcp_PEEK_AT_STACK_POW_4
                                     (if-not-zero    (next     stkcp_PEEK_AT_STACK_POW_4)
-                                                    (if-not-zero    (will-remain-constant!    stkcp_CN_POW_4)
-                                                                    (eq!   (next    (+    stkcp_FIRST_CTXT    stkcp_FIRST_SPOT))    2)
-                                                                    (eq!   (next    stkcp_AGAIN_CTXT)    1))))
+                                                    (if-not    (will-remain-constant!    stkcp_CN_POW_4)
+                                                               (eq!   (next    (+    stkcp_FIRST_CTXT    stkcp_FIRST_SPOT))    2)
+                                                               (eq!   (next    stkcp_AGAIN_CTXT)    1))))
                     (if-not-zero    (next    stkcp_AGAIN_CTXT)
-                                    (if-not-zero    (will-remain-constant!    stkcp_HEIGHT_1234)
-                                                    (eq!    (next    stkcp_FIRST_SPOT)    1)
-                                                    (eq!    (next    stkcp_AGAIN_SPOT)    1)))))
+                                    (if-not    (will-remain-constant!    stkcp_HEIGHT_1234)
+                                               (eq!    (next    stkcp_FIRST_SPOT)    1)
+                                               (eq!    (next    stkcp_AGAIN_SPOT)    1)))))
 
 
 (defconstraint    stack-consistency---first-and-repeat-encounter-of-context ()

--- a/hub/constraints/consistency/storage/constraints.lisp
+++ b/hub/constraints/consistency/storage/constraints.lisp
@@ -50,24 +50,24 @@
 
 (defconstraint    storage-consistency---FIRST-AGAIN-FINAL---repeat-storage-row---change-in-storage-slot  (:guard   (storage-consistency---repeat-storage-row))
                   (begin
-                    (if-not-zero (remained-constant!   (scp_full_address))    (eq! (storage-consistency---transtion-sum)   6))
-                    (if-not-zero (remained-constant!   scp_STORAGE_KEY_HI)    (eq! (storage-consistency---transtion-sum)   6))
-                    (if-not-zero (remained-constant!   scp_STORAGE_KEY_LO)    (eq! (storage-consistency---transtion-sum)   6))))
+                    (if-not (remained-constant!   (scp_full_address))    (eq! (storage-consistency---transtion-sum)   6))
+                    (if-not (remained-constant!   scp_STORAGE_KEY_HI)    (eq! (storage-consistency---transtion-sum)   6))
+                    (if-not (remained-constant!   scp_STORAGE_KEY_LO)    (eq! (storage-consistency---transtion-sum)   6))))
 
 (defconstraint    storage-consistency---FIRST-AGAIN-FINAL---repeat-storage-row---no-change-in-storage-slot  (:guard   (storage-consistency---repeat-storage-row))
-                  (if-zero (remained-constant!   (scp_full_address))
-                           (if-zero (remained-constant!   scp_STORAGE_KEY_HI)
-                                    (if-zero (remained-constant!   scp_STORAGE_KEY_LO)
-                                             (eq! (storage-consistency---transtion-conflation) 0)))))
+                  (if (remained-constant!   (scp_full_address))
+                      (if (remained-constant!   scp_STORAGE_KEY_HI)
+                          (if (remained-constant!   scp_STORAGE_KEY_LO)
+                              (eq! (storage-consistency---transtion-conflation) 0)))))
 
 (defconstraint    storage-consistency---FIRST-AGAIN-FINAL---repeat-encounter-of-storage-slot    (:guard    (*   scp_PEEK_AT_STORAGE    (-   1   scp_FIRST_IN_CNF)))
                   (begin
-                    (if-not-zero    (remained-constant!    scp_REL_BLK_NUM)
-                                    (eq!    (storage-consistency---transtion-block)   2)
-                                    (eq!    (storage-consistency---transtion-block)   0))
-                    (if-not-zero    (remained-constant!    scp_ABS_TX_NUM)
-                                    (eq!    (storage-consistency---transtion-transaction)   2)
-                                    (eq!    (storage-consistency---transtion-transaction)   0))))
+                    (if-not    (remained-constant!    scp_REL_BLK_NUM)
+                               (eq!    (storage-consistency---transtion-block)   2)
+                               (eq!    (storage-consistency---transtion-block)   0))
+                    (if-not    (remained-constant!    scp_ABS_TX_NUM)
+                               (eq!    (storage-consistency---transtion-transaction)   2)
+                               (eq!    (storage-consistency---transtion-transaction)   0))))
 
 (defconstraint    storage-consistency---FIRST-AGAIN-FINAL---final-row-with-room-to-spare ()
                   (if-not-zero (prev scp_PEEK_AT_STORAGE)
@@ -111,16 +111,16 @@
                               (vanishes! scp_VALUE_CURR_LO))))
 
 (defconstraint storage-consistency---resetting-of-storage-values-after-deployments---again (:guard   scp_AGAIN_IN_CNF)
-               (if-not-zero   (remained-constant!   scp_DEPLOYMENT_NUMBER)
-                              (begin
-                                (vanishes! scp_VALUE_CURR_HI)
-                                (vanishes! scp_VALUE_CURR_LO))))
+               (if-not   (remained-constant!   scp_DEPLOYMENT_NUMBER)
+                         (begin
+                            (vanishes! scp_VALUE_CURR_HI)
+                            (vanishes! scp_VALUE_CURR_LO))))
 
 (defconstraint storage-consistency---persisting-of-storage-values (:guard   scp_AGAIN_IN_CNF)
-               (if-zero   (remained-constant!   scp_DEPLOYMENT_NUMBER)
-                          (begin
-                            (eq!   scp_VALUE_CURR_HI   (prev   scp_VALUE_NEXT_HI))
-                            (eq!   scp_VALUE_CURR_LO   (prev   scp_VALUE_NEXT_LO)))))
+               (if   (remained-constant!   scp_DEPLOYMENT_NUMBER)
+                     (begin
+                       (eq!   scp_VALUE_CURR_HI   (prev   scp_VALUE_NEXT_HI))
+                       (eq!   scp_VALUE_CURR_LO   (prev   scp_VALUE_NEXT_LO)))))
 
 (defconstraint setting-and-resetting-storage-key-warmth ()
                (begin

--- a/hub/constraints/generalities/auxiliary_stamps.lisp
+++ b/hub/constraints/generalities/auxiliary_stamps.lisp
@@ -45,8 +45,8 @@
 (defconstraint   generalities---auxiliary-stamps---LOG_INFO_STAMP-increments ()
                  (begin
                    (debug (or! (remained-constant! LOG_INFO_STAMP) (did-inc! LOG_INFO_STAMP 1)))
-                   (if-not-zero (remained-constant! HUB_STAMP)
-                                (did-inc! LOG_INFO_STAMP (* PEEK_AT_STACK stack/LOG_INFO_FLAG)))))
+                   (if-not (remained-constant! HUB_STAMP)
+                           (did-inc! LOG_INFO_STAMP (* PEEK_AT_STACK stack/LOG_INFO_FLAG)))))
 
 (defconstraint   generalities---auxiliary-stamps---necessary-conditions-for-LOG_INFO_FLAG-to-be-on (:perspective stack)
                  (begin (debug (is-binary LOG_INFO_FLAG))

--- a/hub/constraints/generalities/context.lisp
+++ b/hub/constraints/generalities/context.lisp
@@ -79,19 +79,19 @@
 
 (defconstraint    generalities---context-numbers---TX_EXEC-phase---linking-constraint-for-CN-and-CN_NEW ()
                   (if-not-zero TX_EXEC
-                               (if-not-zero (remained-constant! HUB_STAMP)
-                                            (eq! CN (prev CN_NEW)))))
+                               (if-not (remained-constant! HUB_STAMP)
+                                       (eq! CN (prev CN_NEW)))))
 
 (defconstraint    generalities---context-numbers---TX_EXEC-phase---CN-may-only-change-if-CMC ()
                   (if-not-zero TX_EXEC
                                (if-zero CMC (eq! CN_NEW CN))))
 
 (defconstraint    generalities---context-numbers---at-HUB_STAMP-transitions ()
-                  (if-not-zero (will-remain-constant! HUB_STAMP)
-                               (begin
-                                 (if-not-zero CMC   (eq! PEEK_AT_CONTEXT 1))
-                                 (if-not-zero XAHOY (execution-provides-empty-return-data 0))
-                                 (if-not-zero TX_EXEC
+                  (if-not (will-remain-constant! HUB_STAMP)
+                          (begin
+                             (if-not-zero CMC   (eq! PEEK_AT_CONTEXT 1))
+                             (if-not-zero XAHOY (execution-provides-empty-return-data 0))
+                             (if-not-zero TX_EXEC
                                               (if-not-zero CN_NEW
                                                            (eq! (next TX_EXEC) 1)
                                                            (eq! (next TX_FINL) 1))))))

--- a/hub/constraints/generalities/gas.lisp
+++ b/hub/constraints/generalities/gas.lisp
@@ -38,22 +38,22 @@
                              (if-zero   (force-bin  (+  stack/CREATE_FLAG  stack/CALL_FLAG))
                                         (eq!  GAS_NEXT (- GAS_ACTUAL GAS_COST)))))
 
-(defun    (hub-stamp-transition-within-TX_EXEC)   (*   (will-remain-constant! HUB_STAMP)
-                                                       TX_EXEC
-                                                       (next TX_EXEC)))
+(defun    (hub-stamp-transition-within-TX_EXEC)   (or! (will-remain-constant! HUB_STAMP)
+                                                       (eq! TX_EXEC 0)
+                                                       (eq! (next TX_EXEC) 0)))
 
 (defconstraint    gas-columns---hub-stamp-transition-constraints---no-context-change ()
-                  (if-not-zero (hub-stamp-transition-within-TX_EXEC)
-                               (if-eq    CN_NEW    CN
-                                         (eq! (next GAS_ACTUAL) (next GAS_EXPECTED)))))
+                  (if-not (hub-stamp-transition-within-TX_EXEC)
+                            (if-eq    CN_NEW    CN
+                                      (eq! (next GAS_ACTUAL) (next GAS_EXPECTED)))))
 
 (defconstraint    gas-columns---hub-stamp-transition-constraints---re-entering-parent-context ()
-                  (if-not-zero (hub-stamp-transition-within-TX_EXEC)
-                               (if-eq    CN_NEW    CALLER_CN
-                                         (eq! (next GAS_ACTUAL) (+ (next GAS_EXPECTED) GAS_NEXT)))))
+                  (if-not (hub-stamp-transition-within-TX_EXEC)
+                            (if-eq    CN_NEW    CALLER_CN
+                                      (eq! (next GAS_ACTUAL) (+ (next GAS_EXPECTED) GAS_NEXT)))))
 
 (defconstraint    gas-columns---hub-stamp-transition-constraints---entering-child-context ()
-                  (if-not-zero (hub-stamp-transition-within-TX_EXEC)
-                               (if-eq    CN_NEW    (+ 1 HUB_STAMP)
-                                         (eq! (next GAS_ACTUAL) (next GAS_EXPECTED)))))
+                  (if-not (hub-stamp-transition-within-TX_EXEC)
+                            (if-eq    CN_NEW    (+ 1 HUB_STAMP)
+                                      (eq! (next GAS_ACTUAL) (next GAS_EXPECTED)))))
 ;; can't define GAS_EXPECTED at this level of generality

--- a/hub/constraints/generalities/refunds.lisp
+++ b/hub/constraints/generalities/refunds.lisp
@@ -40,8 +40,8 @@
 
 (defconstraint    generalities---gas---refunds-transition-constraints ()
                   (if-not-zero    TX_EXEC
-                                  (if-not-zero    (remained-constant! HUB_STAMP)
-                                                  (eq! REFUND_COUNTER (prev REFUND_COUNTER_NEW)))))
+                                  (if-not    (remained-constant! HUB_STAMP)
+                                             (eq! REFUND_COUNTER (prev REFUND_COUNTER_NEW)))))
 
 (defconstraint    generalities---gas---discard-refunds-if-context-will-revert ()
                   (if-not-zero    CN_WILL_REV

--- a/hub/constraints/generalities/revert_data_specific.lisp
+++ b/hub/constraints/generalities/revert_data_specific.lisp
@@ -65,13 +65,13 @@
                                          (vanishes! CN_GETS_REV))))
 
 (defconstraint child-context-inherits-parent-rollback ()
-               (if-not-zero (remained-constant! HUB_STAMP)
-                            (if-not-zero (prev TX_EXEC)
-                                         (if-not-zero TX_EXEC
-                                                      (if-eq (prev CONTEXT_NUMBER_NEW) HUB_STAMP
-                                                             (begin
-                                                               (eq! CN_GETS_REV (prev CN_WILL_REV))
-                                                               (if-zero CN_SELF_REV (remained-constant! CN_REV_STAMP))))))))
+               (if-not (remained-constant! HUB_STAMP)
+                       (if-not-zero (prev TX_EXEC)
+                                    (if-not-zero TX_EXEC
+                                                 (if-eq (prev CONTEXT_NUMBER_NEW) HUB_STAMP
+                                                        (begin
+                                                           (eq! CN_GETS_REV (prev CN_WILL_REV))
+                                                           (if-zero CN_SELF_REV (remained-constant! CN_REV_STAMP))))))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/hub/constraints/heartbeat/constancy_conditions.lisp
+++ b/hub/constraints/heartbeat/constancy_conditions.lisp
@@ -10,8 +10,8 @@
 
 ;; the following constraint allows to express stamp constancy for stamps that may only increment by 0 or 1
 (defun (constancy-wrt-0-1-increments-stamp stamp  col)
-  (if-not-zero (did-inc! stamp 1)
-               (remained-constant! col)))
+  (if-not (did-inc! stamp 1)
+          (remained-constant! col)))
 
 ;; usecases thereof
 (defun (batch-constancy        col) (constancy-wrt-0-1-increments-stamp    RELATIVE_BLOCK_NUMBER          col))

--- a/hub/constraints/heartbeat/hub_stamp.lisp
+++ b/hub/constraints/heartbeat/hub_stamp.lisp
@@ -37,14 +37,14 @@
                               (will-eq! HUB_STAMP (+ HUB_STAMP PEEK_AT_TRANSACTION))))
 
 (defconstraint   heartbeat---hub-stamp---jumps-at-transaction-boundaries ()
-                 (if-not-zero (will-remain-constant! ABS_TX_NUM)
-                                     (will-inc! HUB_STAMP 1)))
+                 (if-not (will-remain-constant! ABS_TX_NUM)
+                         (will-inc! HUB_STAMP 1)))
 
 (defconstraint   heartbeat---hub-stamp---increments-during-execution-phase ()
                  (if-not-zero TX_EXEC
-                              (begin (if-not-zero (remained-constant! HUB_STAMP)
-                                                  (begin (vanishes! COUNTER_TLI)
-                                                         (vanishes! COUNTER_NSR)))
+                              (begin (if-not (remained-constant! HUB_STAMP)
+                                             (begin (vanishes! COUNTER_TLI)
+                                                    (vanishes! COUNTER_NSR)))
                                      (if-zero COUNTER_NSR
                                               (eq! PEEK_AT_STACK 1)
                                               (vanishes! PEEK_AT_STACK))

--- a/hub/constraints/heartbeat/transaction_phase_flags.lisp
+++ b/hub/constraints/heartbeat/transaction_phase_flags.lisp
@@ -28,8 +28,8 @@
                           (eq! (transaction_phase_sum) 1))))
 
 (defconstraint first-phase-of-new-transaction ()
-               (if-not-zero (remained-constant! ABS_TX_NUM)
-                            (eq! (+ TX_SKIP TX_WARM TX_INIT) 1)))
+               (if-not (remained-constant! ABS_TX_NUM)
+                       (eq! (+ TX_SKIP TX_WARM TX_INIT) 1)))
 
 (defconstraint abs-tx-num-increments ()
                (if-not-zero ABS_TX_NUM

--- a/logdata/constraints.lisp
+++ b/logdata/constraints.lisp
@@ -21,8 +21,8 @@
   (or! (remained-constant! ABS_LOG_NUM) (did-inc! ABS_LOG_NUM 1)))
 
 (defconstraint index-reset ()
-  (if-not-zero (remained-constant! ABS_LOG_NUM)
-               (vanishes! INDEX)))
+  (if-not (remained-constant! ABS_LOG_NUM)
+          (vanishes! INDEX)))
 
 (defconstraint log-logs-no-data (:guard ABS_LOG_NUM)
   (if-zero LOGS_DATA
@@ -33,16 +33,16 @@
                   (did-inc! ABS_LOG_NUM 1))))
 
 (defconstraint log-logs-data (:guard LOGS_DATA)
-  (begin (if-not-zero (remained-constant! ABS_LOG_NUM)
-                      (eq! SIZE_ACC SIZE_LIMB))
-         (if-not-zero (did-inc! ABS_LOG_NUM 1)
-                      (begin (eq! SIZE_ACC
+  (begin (if-not (remained-constant! ABS_LOG_NUM)
+                 (eq! SIZE_ACC SIZE_LIMB))
+         (if-not (did-inc! ABS_LOG_NUM 1)
+                 (begin (eq! SIZE_ACC
                                   (+ (prev SIZE_ACC) SIZE_LIMB))
                              (debug (eq! SIZE_LIMB LLARGE))
                              (did-inc! INDEX 1)))
-         (if-not-zero (will-remain-constant! ABS_LOG_NUM)
-                      (begin (eq! SIZE_TOTAL SIZE_ACC)
-                             (vanishes! (next INDEX))))
+         (if-not (will-remain-constant! ABS_LOG_NUM)
+                 (begin (eq! SIZE_TOTAL SIZE_ACC)
+                        (vanishes! (next INDEX))))
          (debug       (if-eq       SIZE_ACC   SIZE_TOTAL
                       (will-inc!    ABS_LOG_NUM   1)))))
 
@@ -64,8 +64,8 @@
                  (conflation-constancy   ABS_LOG_NUM_MAX))
 
 (defun (log-constancy X)
-  (if-not-zero   (did-inc!           ABS_LOG_NUM 1)
-                 (remained-constant! X)))
+  (if-not   (did-inc!           ABS_LOG_NUM 1)
+            (remained-constant! X)))
 
 (defconstraint log-constancies ()
   (begin (log-constancy SIZE_TOTAL)

--- a/mmio/consistency.lisp
+++ b/mmio/consistency.lisp
@@ -35,13 +35,13 @@
   )
 
 (defconstraint memory-consistency (:guard CN_ABC_SORTED)
-  (begin (if-zero (will-remain-constant! CN_ABC_SORTED)
-                  (if-zero (will-remain-constant! INDEX_ABC_SORTED)
-                           (if-not-zero (will-remain-constant! MMIO_STAMP_3_SORTED)
-                                        (will-eq! VAL_ABC_SORTED VAL_ABC_NEW_SORTED))))
-         (if-not-zero (will-remain-constant! CN_ABC_SORTED)
-                      (will-eq! VAL_ABC_SORTED 0))
-         (if-not-zero (will-remain-constant! INDEX_ABC_SORTED)
-                      (will-eq! VAL_ABC_SORTED 0))))
+  (begin (if (will-remain-constant! CN_ABC_SORTED)
+                  (if (will-remain-constant! INDEX_ABC_SORTED)
+                           (if-not (will-remain-constant! MMIO_STAMP_3_SORTED)
+                                   (will-eq! VAL_ABC_SORTED VAL_ABC_NEW_SORTED))))
+         (if-not (will-remain-constant! CN_ABC_SORTED)
+                 (will-eq! VAL_ABC_SORTED 0))
+         (if-not (will-remain-constant! INDEX_ABC_SORTED)
+                 (will-eq! VAL_ABC_SORTED 0))))
 
 

--- a/mxp/constraints.lisp
+++ b/mxp/constraints.lisp
@@ -173,8 +173,8 @@
        (reduce + (for i [5] [MXP_TYPE i]))))
 
 (defconstraint counter-reset ()
-  (if-not-zero (will-remain-constant! STAMP)
-               (vanishes! (next CT))))
+  (if-not (will-remain-constant! STAMP)
+          (vanishes! (next CT))))
 
 (defconstraint stamp-increment-when-roob-or-noop ()
   (if-not-zero (+ ROOB NOOP)

--- a/oob/constraints.lisp
+++ b/oob/constraints.lisp
@@ -179,8 +179,8 @@
   (or! (remained-constant! STAMP) (did-inc! STAMP 1)))
 
 (defconstraint counter-reset ()
-  (if-not-zero (remained-constant! STAMP)
-               (vanishes! CT)))
+  (if-not (remained-constant! STAMP)
+          (vanishes! CT)))
 
 (defconstraint ct-max ()
   (eq! CT_MAX (maxct-sum)))

--- a/rlpaddr/constraints.lisp
+++ b/rlpaddr/constraints.lisp
@@ -27,8 +27,8 @@
        (eq! STAMP (+ (prev STAMP) 1))))
 
 (defconstraint ct-reset ()
-  (if-not-zero (remained-constant! STAMP)
-               (vanishes! ct)))
+  (if-not (remained-constant! STAMP)
+          (vanishes! ct)))
 
 (defconstraint ct-increment ()
   (begin (if-eq RECIPE_1 1

--- a/rlptxn/constraints.lisp
+++ b/rlptxn/constraints.lisp
@@ -1,9 +1,5 @@
 (module rlptxn)
 
-(defpurefun (if-not-eq A B then)
-  (if-not-zero (- A B)
-               then))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                              ;;
 ;;    2.3 Global Constraints    ;;
@@ -315,15 +311,15 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; 2.3.5.1 & 2.3.5.2
 (defconstraint init-index ()
-  (if-zero (remained-constant! ABS_TX_NUM)
-           (begin (eq! INDEX_LT
-                       (+ (prev INDEX_LT)
-                          (* (prev LC) (prev LT))))
-                  (eq! INDEX_LX
-                       (+ (prev INDEX_LX)
-                          (* (prev LC) (prev LX)))))
-           (begin (vanishes! INDEX_LT)
-                  (vanishes! INDEX_LX))))
+  (if (remained-constant! ABS_TX_NUM)
+      (begin (eq! INDEX_LT
+                   (+ (prev INDEX_LT)
+                      (* (prev LC) (prev LT))))
+             (eq! INDEX_LX
+                   (+ (prev INDEX_LX)
+                      (* (prev LC) (prev LX)))))
+      (begin (vanishes! INDEX_LT)
+             (vanishes! INDEX_LX))))
 
 ;; 2.3.5.3
 (defun (flag-sum-wo-phase-rlp-prefix)

--- a/rom/constraints.lisp
+++ b/rom/constraints.lisp
@@ -120,10 +120,10 @@
                (vanishes! INDEX)))
 
 (defconstraint new-ct-increment-index ()
-  (if-not-zero (or! (eq! CFI 0)
-                    (did-inc! CFI 1)
-                    (neq! CT 0))
-               (did-inc! INDEX 1)))
+  (if-not (or! (eq! CFI 0)
+               (did-inc! CFI 1)
+               (neq! CT 0))
+          (did-inc! INDEX 1)))
 
 (defconstraint index-inc-in-middle-padding ()
   (if-eq CT LLARGE (did-inc! INDEX 1)))

--- a/shakiradata/constraints.lisp
+++ b/shakiradata/constraints.lisp
@@ -168,8 +168,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defconstraint initializing-nBYTES_ACC ()
-  (if-not-zero (remained-constant! SHAKIRA_STAMP)
-               (eq! nBYTES nBYTES_ACC)))
+  (if-not (remained-constant! SHAKIRA_STAMP)
+          (eq! nBYTES nBYTES_ACC)))
 
 (defconstraint updating-nBYTES_ACC-and-ensuring-full-limbs ()
   (if-eq (prev  (shakira---is-data)) 1
@@ -181,7 +181,7 @@
 (defconstraint achieving-total-size ()
   (if-eq (prev (shakira---is-data)) 1
          (if-eq (shakira---is-result) 1
-                (prev (eq! nBYTES_ACC TOTAL_SIZE)))))
+                (eq! (prev nBYTES_ACC) (prev TOTAL_SIZE)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;                                 ;;

--- a/shf/constraints.lisp
+++ b/shf/constraints.lisp
@@ -21,8 +21,8 @@
 
 ;; 2.1.5
 (defconstraint    counter-reset ()
-                  (if-not-zero (will-remain-constant! STAMP)
-                               (vanishes! (shift CT 1))))
+                  (if-not (will-remain-constant! STAMP)
+                          (vanishes! (shift CT 1))))
 
 ;; 2.1.6
 (defconstraint    INST-inside-and-outside-of-padding ()

--- a/stp/constraints.lisp
+++ b/stp/constraints.lisp
@@ -59,8 +59,8 @@
                   (vanishes! (+ WCP_FLAG MOD_FLAG)))))
 
 (defconstraint counter-reset ()
-  (if-not-zero (will-remain-constant! STAMP)
-               (vanishes! (next CT))))
+  (if-not (will-remain-constant! STAMP)
+          (vanishes! (next CT))))
 
 (defconstraint heartbeat (:guard STAMP)
   (begin (if-eq-else CT CT_MAX (will-inc! STAMP 1) (will-inc! CT 1))

--- a/txndata/constraints.lisp
+++ b/txndata/constraints.lisp
@@ -32,8 +32,8 @@
                  (stamp-progression ABS))
 
 (defconstraint   new-stamp-reboot-ct ()
-                 (if-not-zero (will-remain-constant! ABS)
-                              (vanishes! (next CT))))
+                 (if-not (will-remain-constant! ABS)
+                         (vanishes! (next CT))))
 
 (defconstraint   transactions-have-a-single-type (:guard ABS) (eq! (tx-type-sum) 1))
 
@@ -121,8 +121,8 @@
                                      ;;        (vanishes! BLK)
                                      ;;        (vanishes! REL))
                                      )
-                        (if-not-zero (will-inc! BLK 1)
-                                     (will-remain-constant! REL_MAX))))
+                        (if-not (will-inc! BLK 1)
+                                (will-remain-constant! REL_MAX))))
 
 (defconstraint   block-number-increments ()
                  (stamp-progression BLK))
@@ -133,16 +133,16 @@
                                         (vanishes! REL)
                                         ;;(debug (vanishes! BLK_MAX))
                                         (debug (vanishes! REL_MAX))
-                                        (if-not-zero (will-remain-constant! ABS)
-                                                     (begin (eq! (next BLK) 1)
-                                                            (eq! (next REL) 1))))
-                                 (if-not-zero (will-remain-constant! ABS)
-                                              (if-not-eq REL_MAX
-                                                         REL
-                                                         (begin (will-remain-constant! BLK)
-                                                                (will-inc! REL 1))
-                                                         (begin (will-inc! BLK 1)
-                                                                (will-eq! REL 1)))))))
+                                        (if-not (will-remain-constant! ABS)
+                                                (begin (eq! (next BLK) 1)
+                                                       (eq! (next REL) 1))))
+                                 (if-not (will-remain-constant! ABS)
+                                         (if-not-eq REL_MAX
+                                                    REL
+                                                    (begin (will-remain-constant! BLK)
+                                                           (will-inc! REL 1))
+                                                    (begin (will-inc! BLK 1)
+                                                           (will-eq! REL 1)))))))
 
 (defconstraint   set-last-tx-of-block-flag (:guard ABS_TX_NUM)
                  (if-eq-else REL_TX_NUM REL_TX_NUM_MAX
@@ -389,17 +389,17 @@
                              (vanishes! GAS_CUMULATIVE)))
 
 (defconstraint   cumulative-gas---initialization-at-block-start ()
-                        (if-not-zero (will-remain-constant! BLK)
-                                     ; BLK[i + 1] != BLK[i]
-                                     (eq! (next GAS_CUMULATIVE)
-                                          (next (- GAS_LIMIT REFUND_EFFECTIVE)))))
+                        (if-not (will-remain-constant! BLK)
+                                ; BLK[i + 1] != BLK[i]
+                                (eq! (next GAS_CUMULATIVE)
+                                     (next (- GAS_LIMIT REFUND_EFFECTIVE)))))
 
 (defconstraint   cumulative-gas---update-at-transaction-threshold ()
-                 (if-not-zero    (will-inc! BLK 1)
-                                 (if-not-zero    (will-remain-constant! ABS)
+                 (if-not    (will-inc! BLK 1)
+                            (if-not    (will-remain-constant! ABS)
                                                  ; BLK[i + 1] != 1 + BLK[i] && ABS[i+1] != ABS[i] i.e. BLK[i + 1] == BLK[i] && ABS[i+1] == ABS[i] +1
-                                                 (eq!    (next GAS_CUMULATIVE)
-                                                         (+    GAS_CUMULATIVE (next (- GAS_LIMIT REFUND_EFFECTIVE)))))))
+                                            (eq!    (next GAS_CUMULATIVE)
+                                                    (+    GAS_CUMULATIVE (next (- GAS_LIMIT REFUND_EFFECTIVE)))))))
 
 (defconstraint   cumulative-gas-comparison (:guard IS_LAST_TX_OF_BLOCK)
                  (if-not-zero (- ABS_TX_NUM (prev ABS_TX_NUM))

--- a/wcp/constraints.lisp
+++ b/wcp/constraints.lisp
@@ -50,8 +50,8 @@
   (or! (will-remain-constant! STAMP) (will-inc! STAMP 1)))
 
 (defconstraint counter-reset ()
-  (if-not-zero (will-remain-constant! STAMP)
-               (vanishes! (next CT))))
+  (if-not (will-remain-constant! STAMP)
+          (vanishes! (next CT))))
 
 (defconstraint setting-ct-max ()
   (if-eq OLI 1 (vanishes! CT_MAX)))


### PR DESCRIPTION
This puts through a number of cosmetic and trivial changes which will simply reduce the "noise" for the subsequent upgrade to `go-corset` version `1.1`.  Note, for reference, the diff between the constraints before and the constraints after is empty.