### PR TITLE
feat: another pre step before go-corset version 1.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@ee34d9eb60
+      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.0.7
 
     - name: Build Constraints
       run: make -B zkevm.bin

--- a/bin/constraints.lisp
+++ b/bin/constraints.lisp
@@ -47,8 +47,7 @@
                   (vanishes! CT_MAX))))
 
 (defconstraint ct-small ()
-  (eq! 1
-       (~ (- CT LLARGE))))
+  (neq! CT LLARGE))
 
 (defconstraint countereset (:guard STAMP)
   (if-eq-else CT CT_MAX (will-inc! STAMP 1) (will-inc! CT 1)))

--- a/euc/constraints.lisp
+++ b/euc/constraints.lisp
@@ -18,8 +18,7 @@
                                   (will-inc! CT 1))))))
 
 (defconstraint ctmax ()
-  (eq! (~ (- CT MAX_INPUT_LENGTH))
-       1))
+  (neq! CT MAX_INPUT_LENGTH))
 
 (defconstraint counter-constancies ()
   (counter-constancy CT CT_MAX))

--- a/hub/lookups/helpers.lisp
+++ b/hub/lookups/helpers.lisp
@@ -1,3 +1,3 @@
 (defun (unexceptional-stack-row)
-  (and hub.PEEK_AT_STACK
-       (- 1 hub.XAHOY)))
+  (* hub.PEEK_AT_STACK
+    (- 1 hub.XAHOY)))

--- a/hub/lookups/hub_into_add.lisp
+++ b/hub/lookups/hub_into_add.lisp
@@ -1,5 +1,5 @@
 (defun (hub-into-add-activation-flag)
-  (and (unexceptional-stack-row) hub.stack/ADD_FLAG))
+  (* (unexceptional-stack-row) hub.stack/ADD_FLAG))
 
 (deflookup
   hub-into-add

--- a/hub/lookups/hub_into_bin.lisp
+++ b/hub/lookups/hub_into_bin.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-bin-activation-flag)
-  (and (unexceptional-stack-row)
-       hub.stack/BIN_FLAG))
+  (* (unexceptional-stack-row)
+      hub.stack/BIN_FLAG))
 
 (deflookup hub-into-bin
     ;; target columns

--- a/hub/lookups/hub_into_exp.lisp
+++ b/hub/lookups/hub_into_exp.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-exp-trigger)
-  (and hub.PEEK_AT_MISCELLANEOUS
-       hub.misc/EXP_FLAG))
+  (* hub.PEEK_AT_MISCELLANEOUS
+     hub.misc/EXP_FLAG))
 
 (deflookup hub-into-exp
            ;; target columns

--- a/hub/lookups/hub_into_ext.lisp
+++ b/hub/lookups/hub_into_ext.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-ext-activation-flag)
-  (and (unexceptional-stack-row)
-       hub.stack/EXT_FLAG))
+  (* (unexceptional-stack-row)
+      hub.stack/EXT_FLAG))
 
 (deflookup hub-into-ext
     ;; target columns

--- a/hub/lookups/hub_into_mmu.lisp
+++ b/hub/lookups/hub_into_mmu.lisp
@@ -1,5 +1,5 @@
 (defun (hub-into-mmu-trigger)
-  (and hub.PEEK_AT_MISCELLANEOUS hub.misc/MMU_FLAG))
+  (* hub.PEEK_AT_MISCELLANEOUS hub.misc/MMU_FLAG))
 
 (deflookup
   hub-into-mmu

--- a/hub/lookups/hub_into_mod.lisp
+++ b/hub/lookups/hub_into_mod.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-mod-activation-flag)
-  (and (unexceptional-stack-row)
-       hub.stack/MOD_FLAG))
+  (* (unexceptional-stack-row)
+      hub.stack/MOD_FLAG))
 
 (deflookup hub-into-mod
     ;; target columns

--- a/hub/lookups/hub_into_mul.lisp
+++ b/hub/lookups/hub_into_mul.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-mul-activation-flag)
-  (and (unexceptional-stack-row)
-       hub.stack/MUL_FLAG))
+  (* (unexceptional-stack-row)
+      hub.stack/MUL_FLAG))
 
 (deflookup hub-into-mul
     ;; target columns

--- a/hub/lookups/hub_into_mxp.lisp
+++ b/hub/lookups/hub_into_mxp.lisp
@@ -1,5 +1,5 @@
 (defun (hub-into-mxp-trigger)
-  (and hub.PEEK_AT_MISCELLANEOUS hub.misc/MXP_FLAG))
+  (* hub.PEEK_AT_MISCELLANEOUS hub.misc/MXP_FLAG))
 
 (deflookup
   hub-into-mxp

--- a/hub/lookups/hub_into_oob.lisp
+++ b/hub/lookups/hub_into_oob.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-oob-trigger)
-  (and hub.PEEK_AT_MISCELLANEOUS
-       hub.misc/OOB_FLAG))
+  (* hub.PEEK_AT_MISCELLANEOUS
+     hub.misc/OOB_FLAG))
 
 (deflookup hub-into-oob
            ;; target columns

--- a/hub/lookups/hub_into_rlp_addr.lisp
+++ b/hub/lookups/hub_into_rlp_addr.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-rlp-addr-trigger)
-  (and hub.PEEK_AT_ACCOUNT
-       hub.account/RLPADDR_FLAG))
+  (* hub.PEEK_AT_ACCOUNT
+     hub.account/RLPADDR_FLAG))
 
 ;;
 (deflookup hub-into-rlpaddr

--- a/hub/lookups/hub_into_rom_jump_destination_vetting.lisp
+++ b/hub/lookups/hub_into_rom_jump_destination_vetting.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-rom-jump-destination-vetting-trigger)
-  (and hub.PEEK_AT_STACK
-       hub.stack/JUMP_DESTINATION_VETTING_REQUIRED))
+  (* hub.PEEK_AT_STACK
+     hub.stack/JUMP_DESTINATION_VETTING_REQUIRED))
 
 (deflookup hub-into-rom-jump-destination-vetting
            ;; target columns

--- a/hub/lookups/hub_into_rom_lex.lisp
+++ b/hub/lookups/hub_into_rom_lex.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-rom-lex-trigger)
-  (and hub.PEEK_AT_ACCOUNT
-       hub.account/ROMLEX_FLAG))
+  (* hub.PEEK_AT_ACCOUNT
+     hub.account/ROMLEX_FLAG))
 
 
 (deflookup hub-into-romlex

--- a/hub/lookups/hub_into_shf.lisp
+++ b/hub/lookups/hub_into_shf.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-shf-activation-flag)
-  (and (unexceptional-stack-row)
-       hub.stack/SHF_FLAG))
+  (* (unexceptional-stack-row)
+      hub.stack/SHF_FLAG))
 
 (deflookup hub-into-shf
     ;; target columns

--- a/hub/lookups/hub_into_trm.lisp
+++ b/hub/lookups/hub_into_trm.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-trm-trigger)
-  (and hub.PEEK_AT_ACCOUNT
-       hub.account/TRM_FLAG))
+  (* hub.PEEK_AT_ACCOUNT
+     hub.account/TRM_FLAG))
 
 (deflookup hub-into-trm
            ;; target columns

--- a/hub/lookups/hub_into_wcp.lisp
+++ b/hub/lookups/hub_into_wcp.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-wcp-activation-flag)
-  (and (unexceptional-stack-row)
-       hub.stack/WCP_FLAG))
+  (* (unexceptional-stack-row)
+      hub.stack/WCP_FLAG))
 
 (deflookup hub-into-wcp
     ;; target columns

--- a/wcp/constraints.lisp
+++ b/wcp/constraints.lisp
@@ -60,8 +60,7 @@
   (if-eq-else CT CT_MAX (will-inc! STAMP 1) (will-inc! CT 1)))
 
 (defconstraint ct-upper-bond ()
-  (eq! (~ (- LLARGE CT))
-       1))
+  (neq! CT LLARGE))
 
 (defconstraint lastRow (:domain {-1})
   (eq! CT CT_MAX))


### PR DESCRIPTION
This is another simple prestep before upgrading to `go-corset` version `1.1`.  This simply removes `and` which will no longer exist in `go-corset` version `1.1` and replaces it with `*` (which, in fact, is exactly how it is currently defined).

**NOTE**: I have compared the `zkevm.bin` before and after this PR --- there are only a small number of trivial differences.  See attached diff: [zkevm.df5a3474c7.diff.txt](https://github.com/user-attachments/files/19575895/zkevm.df5a3474c7.diff.txt)
