### PR TITLE
feat: Makefile change for one zkevm bin per fork

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,5 +17,5 @@ jobs:
       shell: bash
       run: go install github.com/consensys/go-corset/cmd/go-corset@v1.1.7
 
-    - name: Build Constraints
-      run: make -B zkevm.bin
+    - name: Build all forks
+      run: make -B all

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 zkevm.bin
+zkevm_london.bin
+zkevm_shanghai.bin
 zkevm.go.bin
 zkevm_for_reference_tests.bin
 zkevm_for_old_replay_tests.bin

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ GIT_TAGS := $(shell git -P tag --points-at)
 TIMESTAMP := $(shell date)
 GO_CORSET_COMPILE := ${GO_CORSET} compile -Dtags="${GIT_TAGS}" -Dcommit="${GIT_COMMIT}" -Dtimestamp="${TIMESTAMP}"
 
+# Modules setting
+## Some modules set below are fork specific. Eg. For OOB, OOB_LON is the OOB module for London and OOB_SHAN the OOB module for Shanghai.
+## The discrimination is done by having one bin file per fork - see command line below
+
 ALU := alu
 
 BIN := bin   
@@ -119,10 +123,20 @@ ZKEVM_MODULES_COMMON := ${CONSTANTS} \
 		 ${TRM} \
 		 ${WCP}
 
-ZKEVM_MODULES_LON := ${ZKEVM_MODULES_COMMON} \
-					 ${HUB_LON} \
-					 ${OOB_LON} \
-					 ${TXN_DATA_LON}
+ZKEVM_MODULES_LONDON := ${ZKEVM_MODULES_COMMON} \
+		 ${HUB_LON} \
+		 ${OOB_LON} \
+		 ${TXN_DATA_LON}
 
-zkevm.bin: ${ZKEVM_MODULES}
-	${GO_CORSET_COMPILE} -o $@ ${ZKEVM_MODULES_LON}
+ ZKEVM_MODULES_SHANGHAI := ${ZKEVM_MODULES_COMMON} \
+		 ${HUB_SHAN} \
+		 ${OOB_SHAN} \
+		 ${TXN_DATA_SHAN}
+
+all: zkevm_london.bin zkevm_shanghai.bin
+
+zkevm_london.bin: ${ZKEVM_MODULES_LONDON}
+	${GO_CORSET_COMPILE} -o $@ ${ZKEVM_MODULES_LONDON}
+
+zkevm_shanghai.bin: ${ZKEVM_MODULES_SHANGHAI}
+	${GO_CORSET_COMPILE} -o $@ ${ZKEVM_MODULES_SHANGHAI}

--- a/hub/london/columns/miscellaneous.lisp
+++ b/hub/london/columns/miscellaneous.lisp
@@ -13,11 +13,11 @@
 		 ( STP_FLAG   :binary@prove )
 
 		 ;; EXP columns (DONE)
-		 ( EXP_INST                :i32 )
+		 ( EXP_INST                :i16 )
 		 ( EXP_DATA                :array [5] :i128 )
 
 		 ;; MMU columns (DONE)
-		 ( MMU_INST                :i32   :display :hex)
+		 ( MMU_INST                :i16   :display :hex)
 		 ( MMU_SRC_ID              :i32   )
 		 ( MMU_TGT_ID              :i32   )
 		 ( MMU_AUX_ID              :i32   )
@@ -34,7 +34,7 @@
 		 ( MMU_EXO_SUM             :i32   )
 
 		 ;; MXP colummns
-		 ( MXP_INST                     :i32   )
+		 ( MXP_INST                     :byte   )
 		 ( MXP_MXPX                     :binary ) 
 		 ( MXP_DEPLOYS                  :binary ) 
 		 ( MXP_OFFSET_1_HI              :i128 )


### PR DESCRIPTION
When modules need to be fork dependent, structure is : folder with the name of the module and then subfolders with the names of the forks, like so 
![image](https://github.com/user-attachments/assets/ad02e7dc-883b-4b33-b718-57f4de65601b)

Makefile command lines added to generate one bin file per fork 
- `zkevm_london.bin`
- `zkevm_shanghai.bin`

These bin files are generated using common modules and fork specific ones 

![image](https://github.com/user-attachments/assets/dcd7c820-a852-4924-81b1-591dc5728e3a)



Co-authored by: DavePearce <dave01001110@gmail.com>