### PR TITLE
use defclookup in place of deflookup (for london)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@v1.1.7
+      run: go install github.com/consensys/go-corset/cmd/go-corset@8b2a00a8
 
     - name: Build all forks
       run: make -B all

--- a/bin/lookups/bin_into_binreftable.lisp
+++ b/bin/lookups/bin_into_binreftable.lisp
@@ -1,7 +1,7 @@
 (defun (selector-bin-to-binreftable)
   (+ bin.IS_AND bin.IS_OR bin.IS_XOR bin.IS_NOT))
 
-(deflookup
+(defclookup
   bin-into-binreftable-high
   ;reference columns
   (
@@ -10,15 +10,17 @@
     binreftable.INPUT_BYTE_1
     binreftable.INPUT_BYTE_2
   )
+  ;source selector
+  (selector-bin-to-binreftable)
   ;source columns
   (
-    (* bin.INST (selector-bin-to-binreftable))
-    (* bin.XXX_BYTE_HI (selector-bin-to-binreftable))
-    (* bin.BYTE_1 (selector-bin-to-binreftable))
-    (* bin.BYTE_3 (selector-bin-to-binreftable))
+    bin.INST
+    bin.XXX_BYTE_HI
+    bin.BYTE_1
+    bin.BYTE_3
   ))
 
-(deflookup
+(defclookup
   bin-into-binreftable-low
   ;reference columns
   (
@@ -26,13 +28,15 @@
     binreftable.RESULT_BYTE
     binreftable.INPUT_BYTE_1
     binreftable.INPUT_BYTE_2
-  )
+    )
+  ;source selector
+  (selector-bin-to-binreftable)
   ;source columns
   (
-    (* bin.INST (selector-bin-to-binreftable))
-    (* bin.XXX_BYTE_LO (selector-bin-to-binreftable))
-    (* bin.BYTE_2 (selector-bin-to-binreftable))
-    (* bin.BYTE_4 (selector-bin-to-binreftable))
+    bin.INST
+    bin.XXX_BYTE_LO
+    bin.BYTE_2
+    bin.BYTE_4
   ))
 
 

--- a/blake2fmodexpdata/lookups/blakemodexp_into_wcp.lisp
+++ b/blake2fmodexpdata/lookups/blakemodexp_into_wcp.lisp
@@ -2,9 +2,9 @@
   (force-bin (* (~ blake2fmodexpdata.STAMP)
                 (- blake2fmodexpdata.STAMP (prev blake2fmodexpdata.STAMP)))))
 
-(deflookup
+(defclookup
   blake2fmodexpdata-into-wcp
-  ; target colums (in WCP)
+  ;; target colums (in WCP)
   (
     wcp.ARG_1_HI
     wcp.ARG_1_LO
@@ -13,14 +13,16 @@
     wcp.RES
     wcp.INST
   )
-  ; source columns
+  ;; source selector
+  (blake2fmodexpdata-into-wcp-oob-into-wcp-activation-flag)
+  ;; source columns
   (
     0
-    (* (blake2fmodexpdata-into-wcp-oob-into-wcp-activation-flag) (prev blake2fmodexpdata.ID))
+    (prev blake2fmodexpdata.ID)
     0
-    (* (blake2fmodexpdata-into-wcp-oob-into-wcp-activation-flag) blake2fmodexpdata.ID)
-    (* (blake2fmodexpdata-into-wcp-oob-into-wcp-activation-flag) 1)
-    (* (blake2fmodexpdata-into-wcp-oob-into-wcp-activation-flag) EVM_INST_LT)
+    blake2fmodexpdata.ID
+    1
+    EVM_INST_LT
   ))
 
 

--- a/blockdata/london/lookups/blockdata_into_euc.lisp
+++ b/blockdata/london/lookups/blockdata_into_euc.lisp
@@ -1,6 +1,6 @@
 (defun (blockdata-into-euc-selector) blockdata.EUC_FLAG)
 
-(deflookup 
+(defclookup 
   blockdata-into-euc
   ;; target columns
   (
@@ -9,11 +9,13 @@
     euc.DIVISOR
     euc.QUOTIENT
   )
+  ;; source selector
+  (blockdata-into-euc-selector)
   ;; source columns
   (
-    (* 1                  (blockdata-into-euc-selector))
-    (* blockdata.ARG_1_LO (blockdata-into-euc-selector))
-    (* blockdata.ARG_2_LO (blockdata-into-euc-selector))
-    (* blockdata.RES      (blockdata-into-euc-selector))
+    1
+    blockdata.ARG_1_LO
+    blockdata.ARG_2_LO
+    blockdata.RES
   ))
 

--- a/blockdata/london/lookups/blockdata_into_wcp.lisp
+++ b/blockdata/london/lookups/blockdata_into_wcp.lisp
@@ -1,7 +1,7 @@
 (defun (blockdata-into-wcp-selector)
   blockdata.WCP_FLAG)
 
-(deflookup 
+(defclookup 
   blockdata-into-wcp
   ;; target columns
   (
@@ -12,13 +12,15 @@
     wcp.RESULT
     wcp.INST
   )
+  ;; source selector
+  (blockdata-into-wcp-selector)
   ;; source columns
   (
-    (* blockdata.ARG_1_HI (blockdata-into-wcp-selector))
-    (* blockdata.ARG_1_LO (blockdata-into-wcp-selector))
-    (* blockdata.ARG_2_HI (blockdata-into-wcp-selector))
-    (* blockdata.ARG_2_LO (blockdata-into-wcp-selector))
-    (* blockdata.RES      (blockdata-into-wcp-selector))
-    (* blockdata.EXO_INST (blockdata-into-wcp-selector))
+    blockdata.ARG_1_HI
+    blockdata.ARG_1_LO
+    blockdata.ARG_2_HI
+    blockdata.ARG_2_LO
+    blockdata.RES
+    blockdata.EXO_INST
   ))
 

--- a/blockhash/lookups/blockhash_into_blockdata.lisp
+++ b/blockhash/lookups/blockhash_into_blockdata.lisp
@@ -1,17 +1,19 @@
 (defun   (blockhash-into-blockdata-selector)   blockhash.MACRO) ;; ""
 
-(deflookup
+(defclookup
   blockhash-into-blockdata
-  ; target columns
+  ;; target columns
   (
    blockdata.REL_BLOCK
    blockdata.DATA_LO
    blockdata.INST
-   )
-  ; source columns
+  )
+  ;; source selector
+  (blockhash-into-blockdata-selector)
+  ;; source columns
   (
-   (* (blockhash-into-blockdata-selector)   blockhash.macro/REL_BLOCK)
-   (* (blockhash-into-blockdata-selector)   blockhash.macro/ABS_BLOCK)
-   (* (blockhash-into-blockdata-selector)   EVM_INST_NUMBER)
+   blockhash.macro/REL_BLOCK
+   blockhash.macro/ABS_BLOCK
+   EVM_INST_NUMBER
    )
   )

--- a/blockhash/lookups/blockhash_into_wcp.lisp
+++ b/blockhash/lookups/blockhash_into_wcp.lisp
@@ -1,8 +1,8 @@
 (defun   (blockhash-into-wcp-selector)   blockhash.PRPRC) ;; ""
 
-(deflookup
+(defclookup
   blockhash-into-wcp-lex
-  ; target columns
+  ;; target columns
   (
    wcp.ARGUMENT_1_HI
    wcp.ARGUMENT_1_LO
@@ -10,15 +10,17 @@
    wcp.ARGUMENT_2_LO
    wcp.INST
    wcp.RESULT
-   )
-  ; source columns
+  )
+  ;; source selector
+  (blockhash-into-wcp-selector)
+  ;; source columns
   (
-   (*   blockhash.preprocessing/EXO_ARG_1_HI   (blockhash-into-wcp-selector))
-   (*   blockhash.preprocessing/EXO_ARG_1_LO   (blockhash-into-wcp-selector))
-   (*   blockhash.preprocessing/EXO_ARG_2_HI   (blockhash-into-wcp-selector))
-   (*   blockhash.preprocessing/EXO_ARG_2_LO   (blockhash-into-wcp-selector))
-   (*   blockhash.preprocessing/EXO_INST       (blockhash-into-wcp-selector))
-   (*   blockhash.preprocessing/EXO_RES        (blockhash-into-wcp-selector))
+   blockhash.preprocessing/EXO_ARG_1_HI
+   blockhash.preprocessing/EXO_ARG_1_LO
+   blockhash.preprocessing/EXO_ARG_2_HI
+   blockhash.preprocessing/EXO_ARG_2_LO
+   blockhash.preprocessing/EXO_INST
+   blockhash.preprocessing/EXO_RES
    )
   )
 

--- a/ecdata/lookups/ecdata_into_ext.lisp
+++ b/ecdata/lookups/ecdata_into_ext.lisp
@@ -1,9 +1,9 @@
 (defun (ec_data-into-ext-activation-flag)
   ecdata.EXT_FLAG)
 
-(deflookup
+(defclookup
   ecdata-into-ext
-  ; target columns
+  ;; target columns
   (
     ext.ARG_1_HI
     ext.ARG_1_LO
@@ -15,17 +15,19 @@
     ext.RES_LO
     ext.INST
   )
-  ; source columns
+  ;; source selector
+  (ec_data-into-ext-activation-flag)
+  ;; source columns
   (
-    (* ecdata.EXT_ARG1_HI (ec_data-into-ext-activation-flag))
-    (* ecdata.EXT_ARG1_LO (ec_data-into-ext-activation-flag))
-    (* ecdata.EXT_ARG2_HI (ec_data-into-ext-activation-flag))
-    (* ecdata.EXT_ARG2_LO (ec_data-into-ext-activation-flag))
-    (* ecdata.EXT_ARG3_HI (ec_data-into-ext-activation-flag))
-    (* ecdata.EXT_ARG3_LO (ec_data-into-ext-activation-flag))
-    (* ecdata.EXT_RES_HI (ec_data-into-ext-activation-flag))
-    (* ecdata.EXT_RES_LO (ec_data-into-ext-activation-flag))
-    (* ecdata.EXT_INST (ec_data-into-ext-activation-flag))
+    ecdata.EXT_ARG1_HI
+    ecdata.EXT_ARG1_LO
+    ecdata.EXT_ARG2_HI
+    ecdata.EXT_ARG2_LO
+    ecdata.EXT_ARG3_HI
+    ecdata.EXT_ARG3_LO
+    ecdata.EXT_RES_HI
+    ecdata.EXT_RES_LO
+    ecdata.EXT_INST
   ))
 
 

--- a/ecdata/lookups/ecdata_into_wcp.lisp
+++ b/ecdata/lookups/ecdata_into_wcp.lisp
@@ -1,9 +1,9 @@
 (defun (ec_data-into-wcp-activation-flag)
   ecdata.WCP_FLAG)
 
-(deflookup
+(defclookup
   ecdata-into-wcp
-  ; target columns
+  ;; target columns
   (
     wcp.ARGUMENT_1_HI
     wcp.ARGUMENT_1_LO
@@ -12,14 +12,16 @@
     wcp.RESULT
     wcp.INST
   )
-  ; source columns
+  ;; source selector
+  (ec_data-into-wcp-activation-flag)
+  ;; source columns
   (
-    (* ecdata.WCP_ARG1_HI (ec_data-into-wcp-activation-flag))
-    (* ecdata.WCP_ARG1_LO (ec_data-into-wcp-activation-flag))
-    (* ecdata.WCP_ARG2_HI (ec_data-into-wcp-activation-flag))
-    (* ecdata.WCP_ARG2_LO (ec_data-into-wcp-activation-flag))
-    (* ecdata.WCP_RES (ec_data-into-wcp-activation-flag))
-    (* ecdata.WCP_INST (ec_data-into-wcp-activation-flag))
+    ecdata.WCP_ARG1_HI
+    ecdata.WCP_ARG1_LO
+    ecdata.WCP_ARG2_HI
+    ecdata.WCP_ARG2_LO
+    ecdata.WCP_RES
+    ecdata.WCP_INST
   ))
 
 

--- a/euc/lookups/euc_into_wcp.lisp
+++ b/euc/lookups/euc_into_wcp.lisp
@@ -1,6 +1,6 @@
-(deflookup
+(defclookup
   euc-into-wcp
-  ;reference columns
+  ;; target columns
   (
     wcp.ARG_1_HI
     wcp.ARG_1_LO
@@ -9,14 +9,16 @@
     wcp.RES
     wcp.INST
   )
-  ;source columns
+  ;; source selector
+  euc.DONE
+  ;; source columns
   (
     0
-    (* euc.REMAINDER euc.DONE)
+    euc.REMAINDER
     0
-    (* euc.DIVISOR   euc.DONE)
-    (* 1             euc.DONE)
-    (* EVM_INST_LT   euc.DONE)
+    euc.DIVISOR
+    1
+    EVM_INST_LT
   ))
 
 

--- a/exp/lookups/exp-into-wcp.lisp
+++ b/exp/lookups/exp-into-wcp.lisp
@@ -1,6 +1,6 @@
 (defun (exp-into-wcp-activation-flag) (* exp.PRPRC exp.preprocessing/WCP_FLAG))
 
-(deflookup
+(defclookup
   exp-into-wcp
   ;; target columns
   (
@@ -11,14 +11,16 @@
     wcp.RESULT
     wcp.INST
   )
+  ;; source selector
+  (exp-into-wcp-activation-flag)
   ;; source columns
   (
-    (*   exp.preprocessing/WCP_ARG_1_HI   (exp-into-wcp-activation-flag))
-    (*   exp.preprocessing/WCP_ARG_1_LO   (exp-into-wcp-activation-flag))
-    (*   exp.preprocessing/WCP_ARG_2_HI   (exp-into-wcp-activation-flag))
-    (*   exp.preprocessing/WCP_ARG_2_LO   (exp-into-wcp-activation-flag))
-    (*   exp.preprocessing/WCP_RES        (exp-into-wcp-activation-flag))
-    (*   exp.preprocessing/WCP_INST       (exp-into-wcp-activation-flag))
+    exp.preprocessing/WCP_ARG_1_HI
+    exp.preprocessing/WCP_ARG_1_LO
+    exp.preprocessing/WCP_ARG_2_HI
+    exp.preprocessing/WCP_ARG_2_LO
+    exp.preprocessing/WCP_RES
+    exp.preprocessing/WCP_INST
   ))
 
 

--- a/gas/lookups/gas-into-wcp.lisp
+++ b/gas/lookups/gas-into-wcp.lisp
@@ -1,8 +1,9 @@
 (defun (gas-into-wcp-activation-flag)
   gas.IOMF)
 
-(deflookup
-  gas-into-wcp
+(defclookup
+    gas-into-wcp
+  ;; target columns
   (
     wcp.ARG_1_HI
     wcp.ARG_1_LO
@@ -11,13 +12,16 @@
     wcp.RES
     wcp.INST
   )
+  ;; source selector
+  (gas-into-wcp-activation-flag)
+  ;; source columns
   (
     0
-    (* gas.WCP_ARG1_LO (gas-into-wcp-activation-flag))
+    gas.WCP_ARG1_LO
     0
-    (* gas.WCP_ARG2_LO (gas-into-wcp-activation-flag))
-    (* gas.WCP_RES     (gas-into-wcp-activation-flag))
-    (* gas.WCP_INST    (gas-into-wcp-activation-flag))
+    gas.WCP_ARG2_LO
+    gas.WCP_RES
+    gas.WCP_INST
   ))
 
 

--- a/hub/london/lookups/hub_into_add.lisp
+++ b/hub/london/lookups/hub_into_add.lisp
@@ -1,7 +1,7 @@
 (defun (hub-into-add-activation-flag)
   (* (unexceptional-stack-row) hub.stack/ADD_FLAG))
 
-(deflookup
+(defclookup
   hub-into-add
   ;; target columns
   (
@@ -13,15 +13,17 @@
     add.RES_LO
     add.INST
   )
+  ;; source selector
+  (hub-into-add-activation-flag)
   ;; source columns
   (
-    (* [hub.stack/STACK_ITEM_VALUE_HI 1] (hub-into-add-activation-flag)) ;; arg1
-    (* [hub.stack/STACK_ITEM_VALUE_LO 1] (hub-into-add-activation-flag))
-    (* [hub.stack/STACK_ITEM_VALUE_HI 2] (hub-into-add-activation-flag)) ;; arg2
-    (* [hub.stack/STACK_ITEM_VALUE_LO 2] (hub-into-add-activation-flag))
-    (* [hub.stack/STACK_ITEM_VALUE_HI 4] (hub-into-add-activation-flag)) ;; result
-    (* [hub.stack/STACK_ITEM_VALUE_LO 4] (hub-into-add-activation-flag))
-    (* hub.stack/INSTRUCTION             (hub-into-add-activation-flag)) ;; instruction
+    [hub.stack/STACK_ITEM_VALUE_HI 1] ;; arg1
+    [hub.stack/STACK_ITEM_VALUE_LO 1]
+    [hub.stack/STACK_ITEM_VALUE_HI 2] ;; arg2
+    [hub.stack/STACK_ITEM_VALUE_LO 2]
+    [hub.stack/STACK_ITEM_VALUE_HI 4] ;; result
+    [hub.stack/STACK_ITEM_VALUE_LO 4]
+    hub.stack/INSTRUCTION ;; instruction
   ))
 
 

--- a/hub/london/lookups/hub_into_bin.lisp
+++ b/hub/london/lookups/hub_into_bin.lisp
@@ -2,25 +2,27 @@
   (* (unexceptional-stack-row)
       hub.stack/BIN_FLAG))
 
-(deflookup hub-into-bin
-    ;; target columns
-    (
-        bin.ARG_1_HI
-        bin.ARG_1_LO
-        bin.ARG_2_HI
-        bin.ARG_2_LO
-        bin.RES_HI
-        bin.RES_LO
-        bin.INST
-    )
-    ;; source columns
-    (
-        (* [hub.stack/STACK_ITEM_VALUE_HI 1]     (hub-into-bin-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 1]     (hub-into-bin-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 2]     (hub-into-bin-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 2]     (hub-into-bin-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 4]     (hub-into-bin-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 4]     (hub-into-bin-activation-flag))
-        (*  hub.stack/INSTRUCTION                (hub-into-bin-activation-flag))
-    )
+(defclookup hub-into-bin
+  ;; target columns
+  (
+   bin.ARG_1_HI
+   bin.ARG_1_LO
+   bin.ARG_2_HI
+   bin.ARG_2_LO
+   bin.RES_HI
+   bin.RES_LO
+   bin.INST
+  )
+  ;; source selector
+  (hub-into-bin-activation-flag)
+  ;; source columns
+  (
+   [hub.stack/STACK_ITEM_VALUE_HI 1]
+   [hub.stack/STACK_ITEM_VALUE_LO 1]
+   [hub.stack/STACK_ITEM_VALUE_HI 2]
+   [hub.stack/STACK_ITEM_VALUE_LO 2]
+   [hub.stack/STACK_ITEM_VALUE_HI 4]
+   [hub.stack/STACK_ITEM_VALUE_LO 4]
+    hub.stack/INSTRUCTION
+  )
 )

--- a/hub/london/lookups/hub_into_block_data.lisp
+++ b/hub/london/lookups/hub_into_block_data.lisp
@@ -3,19 +3,21 @@
                                         hub.stack/BTC_FLAG
                                         (- 1 [hub.stack/DEC_FLAG 1])))
 
-(deflookup hub-into-blockdata
-           ;; target columns
-           (
-             blockdata.REL_BLOCK
-             blockdata.INST
-             blockdata.DATA_HI
-             blockdata.DATA_LO
-             )
-           ;; source columns
-           (
-            (* hub.RELATIVE_BLOCK_NUMBER          (hub-into-block-data-trigger))
-            (* hub.stack/INSTRUCTION              (hub-into-block-data-trigger))
-            (* [hub.stack/STACK_ITEM_VALUE_HI 4]  (hub-into-block-data-trigger))
-            (* [hub.stack/STACK_ITEM_VALUE_LO 4]  (hub-into-block-data-trigger))
-            )
-           )
+(defclookup hub-into-blockdata
+  ;; target columns
+  (
+   blockdata.REL_BLOCK
+   blockdata.INST
+   blockdata.DATA_HI
+   blockdata.DATA_LO
+  )
+  ;; source selector
+  (hub-into-block-data-trigger)
+  ;; source columns
+  (
+   hub.RELATIVE_BLOCK_NUMBER
+   hub.stack/INSTRUCTION
+   [hub.stack/STACK_ITEM_VALUE_HI 4]
+   [hub.stack/STACK_ITEM_VALUE_LO 4]
+  )
+)

--- a/hub/london/lookups/hub_into_block_hash.lisp
+++ b/hub/london/lookups/hub_into_block_hash.lisp
@@ -1,7 +1,7 @@
 (defun (hub-into-block-hash-trigger)
   (* hub.PEEK_AT_STACK (- 1 hub.XAHOY) hub.stack/BTC_FLAG [hub.stack/DEC_FLAG 1]))
 
-(deflookup
+(defclookup
   hub-into-blockhash
   ;; target columns
   (
@@ -11,13 +11,15 @@
     blockhash.macro/BLOCKHASH_RES_HI
     blockhash.macro/BLOCKHASH_RES_LO
   )
+  ;; source selector
+  (hub-into-block-hash-trigger)
   ;; source columns
   (
-    (*  hub.RELATIVE_BLOCK_NUMBER        (hub-into-block-hash-trigger))
-    (* [hub.stack/STACK_ITEM_VALUE_HI 1] (hub-into-block-hash-trigger))
-    (* [hub.stack/STACK_ITEM_VALUE_LO 1] (hub-into-block-hash-trigger))
-    (* [hub.stack/STACK_ITEM_VALUE_HI 4] (hub-into-block-hash-trigger))
-    (* [hub.stack/STACK_ITEM_VALUE_LO 4] (hub-into-block-hash-trigger))
+    hub.RELATIVE_BLOCK_NUMBER
+    [hub.stack/STACK_ITEM_VALUE_HI 1]
+    [hub.stack/STACK_ITEM_VALUE_LO 1]
+    [hub.stack/STACK_ITEM_VALUE_HI 4]
+    [hub.stack/STACK_ITEM_VALUE_LO 4]
   ))
 
 

--- a/hub/london/lookups/hub_into_exp.lisp
+++ b/hub/london/lookups/hub_into_exp.lisp
@@ -2,25 +2,27 @@
   (* hub.PEEK_AT_MISCELLANEOUS
      hub.misc/EXP_FLAG))
 
-(deflookup hub-into-exp
-           ;; target columns
-           (
-             exp.MACRO
-             exp.macro/EXP_INST
-             [exp.macro/DATA 1]
-             [exp.macro/DATA 2]
-             [exp.macro/DATA 3]
-             [exp.macro/DATA 4]
-             [exp.macro/DATA 5]
-             )
-           ;; source columns
-           (
-            (* 1                         (hub-into-exp-trigger))
-            (* hub.misc/EXP_INST         (hub-into-exp-trigger))
-            (* [hub.misc/EXP_DATA 1]     (hub-into-exp-trigger))
-            (* [hub.misc/EXP_DATA 2]     (hub-into-exp-trigger))
-            (* [hub.misc/EXP_DATA 3]     (hub-into-exp-trigger))
-            (* [hub.misc/EXP_DATA 4]     (hub-into-exp-trigger))
-            (* [hub.misc/EXP_DATA 5]     (hub-into-exp-trigger))
-            )
-           )
+(defclookup hub-into-exp
+  ;; target columns
+  (
+   exp.MACRO
+   exp.macro/EXP_INST
+   [exp.macro/DATA 1]
+   [exp.macro/DATA 2]
+   [exp.macro/DATA 3]
+   [exp.macro/DATA 4]
+   [exp.macro/DATA 5]
+  )
+  ;; source selector
+  (hub-into-exp-trigger)
+  ;; source columns
+  (
+   1
+   hub.misc/EXP_INST
+   [hub.misc/EXP_DATA 1]
+   [hub.misc/EXP_DATA 2]
+   [hub.misc/EXP_DATA 3]
+   [hub.misc/EXP_DATA 4]
+   [hub.misc/EXP_DATA 5]
+  )
+)

--- a/hub/london/lookups/hub_into_ext.lisp
+++ b/hub/london/lookups/hub_into_ext.lisp
@@ -2,29 +2,31 @@
   (* (unexceptional-stack-row)
       hub.stack/EXT_FLAG))
 
-(deflookup hub-into-ext
-    ;; target columns
-    (
-        ext.ARG_1_HI
-        ext.ARG_1_LO
-        ext.ARG_2_HI
-        ext.ARG_2_LO
-        ext.ARG_3_HI
-        ext.ARG_3_LO
-        ext.RES_HI
-        ext.RES_LO
-        ext.INST
-    )
-    ;; source columns
-    (
-        (* [hub.stack/STACK_ITEM_VALUE_HI 1]     (hub-into-ext-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 1]     (hub-into-ext-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 2]     (hub-into-ext-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 2]     (hub-into-ext-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 3]     (hub-into-ext-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 3]     (hub-into-ext-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 4]     (hub-into-ext-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 4]     (hub-into-ext-activation-flag))
-        (*  hub.stack/INSTRUCTION                (hub-into-ext-activation-flag))
-    )
+(defclookup hub-into-ext
+  ;; target columns
+  (
+   ext.ARG_1_HI
+   ext.ARG_1_LO
+   ext.ARG_2_HI
+   ext.ARG_2_LO
+   ext.ARG_3_HI
+   ext.ARG_3_LO
+   ext.RES_HI
+   ext.RES_LO
+   ext.INST
+  )
+  ;; source selector
+  (hub-into-ext-activation-flag)
+  ;; source columns
+  (
+   [hub.stack/STACK_ITEM_VALUE_HI 1]
+   [hub.stack/STACK_ITEM_VALUE_LO 1]
+   [hub.stack/STACK_ITEM_VALUE_HI 2]
+   [hub.stack/STACK_ITEM_VALUE_LO 2]
+   [hub.stack/STACK_ITEM_VALUE_HI 3]
+   [hub.stack/STACK_ITEM_VALUE_LO 3]
+   [hub.stack/STACK_ITEM_VALUE_HI 4]
+   [hub.stack/STACK_ITEM_VALUE_LO 4]
+    hub.stack/INSTRUCTION
+  )
 )

--- a/hub/london/lookups/hub_into_gas.lisp
+++ b/hub/london/lookups/hub_into_gas.lisp
@@ -1,20 +1,22 @@
 (defun (hub-into-gas-trigger) (* hub.PEEK_AT_STACK hub.CMC))
 
-(deflookup hub-into-gas
-           ;; target columns
-	   (
-	     gas.IOMF
-	     gas.GAS_ACTUAL
-	     gas.GAS_COST
-	     gas.EXCEPTIONS_AHOY
-	     gas.OUT_OF_GAS_EXCEPTION
-           )
-           ;; source columns
-	   (
-	                          (hub-into-gas-trigger)
-	     (* hub.GAS_ACTUAL    (hub-into-gas-trigger))
-	     (* hub.GAS_COST      (hub-into-gas-trigger))
-	     (* hub.XAHOY         (hub-into-gas-trigger))
-	     (* hub.stack/OOGX    (hub-into-gas-trigger))
-           )
+(defclookup hub-into-gas
+  ;; target columns
+  (
+   gas.IOMF
+   gas.GAS_ACTUAL
+   gas.GAS_COST
+   gas.EXCEPTIONS_AHOY
+   gas.OUT_OF_GAS_EXCEPTION
+  )
+  ;; source selector
+  (hub-into-gas-trigger)
+  ;; source columns
+  (
+   1
+   hub.GAS_ACTUAL
+   hub.GAS_COST
+   hub.XAHOY
+   hub.stack/OOGX
+   )
 )

--- a/hub/london/lookups/hub_into_hub.lisp
+++ b/hub/london/lookups/hub_into_hub.lisp
@@ -1,26 +1,30 @@
 (defun    (hub-into-hub-source-selector)    hub.scp_PEEK_AT_STORAGE)
 (defun    (hub-into-hub-target-selector)    hub.acp_PEEK_AT_ACCOUNT) ;; ""
 
-(deflookup hub-into-hub---FIRST-FINAL-in-block-deployment-number-coherence
-	   ;; target columns
-	   (
-	    (* hub.acp_ADDRESS_HI                                 (hub-into-hub-target-selector))
-	    (* hub.acp_ADDRESS_LO                                 (hub-into-hub-target-selector))
-	    (* hub.acp_REL_BLK_NUM                                (hub-into-hub-target-selector))
-	    (* hub.acp_DEPLOYMENT_NUMBER_FIRST_IN_BLOCK           (hub-into-hub-target-selector))
-	    (* hub.acp_DEPLOYMENT_NUMBER_FINAL_IN_BLOCK           (hub-into-hub-target-selector))
-	    (* hub.acp_EXISTS_FIRST_IN_BLOCK                      (hub-into-hub-target-selector))
-	    (* hub.acp_EXISTS_FINAL_IN_BLOCK                      (hub-into-hub-target-selector))
-	    )
-	   ;; source columns
-	   (
-	    (* hub.scp_ADDRESS_HI                                 (hub-into-hub-source-selector))
-	    (* hub.scp_ADDRESS_LO                                 (hub-into-hub-source-selector))
-	    (* hub.scp_REL_BLK_NUM                                (hub-into-hub-source-selector))
-	    (* hub.scp_DEPLOYMENT_NUMBER_FIRST_IN_BLOCK           (hub-into-hub-source-selector))
-	    (* hub.scp_DEPLOYMENT_NUMBER_FINAL_IN_BLOCK           (hub-into-hub-source-selector))
-	    (* hub.scp_EXISTS_FIRST_IN_BLOCK                      (hub-into-hub-source-selector))
-	    (* hub.scp_EXISTS_FINAL_IN_BLOCK                      (hub-into-hub-source-selector))
-	    )
-	   )
+(defclookup hub-into-hub---FIRST-FINAL-in-block-deployment-number-coherence
+  ;; target selector
+  (hub-into-hub-target-selector)
+  ;; target columns
+  (
+   hub.acp_ADDRESS_HI
+   hub.acp_ADDRESS_LO
+   hub.acp_REL_BLK_NUM
+   hub.acp_DEPLOYMENT_NUMBER_FIRST_IN_BLOCK
+   hub.acp_DEPLOYMENT_NUMBER_FINAL_IN_BLOCK
+   hub.acp_EXISTS_FIRST_IN_BLOCK
+   hub.acp_EXISTS_FINAL_IN_BLOCK
+  )
+  ;; source selector
+  (hub-into-hub-source-selector)
+  ;; source columns
+  (
+   hub.scp_ADDRESS_HI
+   hub.scp_ADDRESS_LO
+   hub.scp_REL_BLK_NUM
+   hub.scp_DEPLOYMENT_NUMBER_FIRST_IN_BLOCK
+   hub.scp_DEPLOYMENT_NUMBER_FINAL_IN_BLOCK
+   hub.scp_EXISTS_FIRST_IN_BLOCK
+   hub.scp_EXISTS_FINAL_IN_BLOCK
+  )
+)
 

--- a/hub/london/lookups/hub_into_instruction_decoder.lisp
+++ b/hub/london/lookups/hub_into_instruction_decoder.lisp
@@ -1,87 +1,88 @@
 (defun (hub-into-instruction-decoder-trigger) hub.PEEK_AT_STACK)
 
-(deflookup hub-into-instdecoder
-           ;; target columns
-	   (
-	     instdecoder.OPCODE
-	     instdecoder.STATIC_GAS
-	     instdecoder.TWO_LINE_INSTRUCTION
-	     instdecoder.FLAG_1
-	     instdecoder.FLAG_2
-	     instdecoder.FLAG_3
-	     instdecoder.FLAG_4
-	     instdecoder.MXP_FLAG
-	     instdecoder.STATIC_FLAG
-	     instdecoder.ALPHA
-	     instdecoder.DELTA
-	     ;;
-	     instdecoder.FAMILY_ACCOUNT
-	     instdecoder.FAMILY_ADD
-	     instdecoder.FAMILY_BIN
-	     instdecoder.FAMILY_BATCH
-	     instdecoder.FAMILY_CALL
-	     instdecoder.FAMILY_CONTEXT
-	     instdecoder.FAMILY_COPY
-	     instdecoder.FAMILY_CREATE
-	     instdecoder.FAMILY_DUP
-	     instdecoder.FAMILY_EXT
-	     instdecoder.FAMILY_HALT
-	     instdecoder.FAMILY_INVALID
-	     instdecoder.FAMILY_JUMP
-	     instdecoder.FAMILY_KEC
-	     instdecoder.FAMILY_LOG
-	     instdecoder.FAMILY_MACHINE_STATE
-	     instdecoder.FAMILY_MOD
-	     instdecoder.FAMILY_MUL
-	     instdecoder.FAMILY_PUSH_POP
-	     instdecoder.FAMILY_SHF
-	     instdecoder.FAMILY_STACK_RAM
-	     instdecoder.FAMILY_STORAGE
-	     instdecoder.FAMILY_SWAP
-	     instdecoder.FAMILY_TRANSACTION
-	     instdecoder.FAMILY_WCP
-	     ;;
-           )
-
-           ;; source columns
-	   (
-	     (* hub.stack/INSTRUCTION                 (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/STATIC_GAS                  (hub-into-instruction-decoder-trigger))
-	     (* hub.TWO_LINE_INSTRUCTION              (hub-into-instruction-decoder-trigger))
-	     (* [hub.stack/DEC_FLAG 1]                (hub-into-instruction-decoder-trigger))
-	     (* [hub.stack/DEC_FLAG 2]                (hub-into-instruction-decoder-trigger))
-	     (* [hub.stack/DEC_FLAG 3]                (hub-into-instruction-decoder-trigger))
-	     (* [hub.stack/DEC_FLAG 4]                (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/MXP_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/STATIC_FLAG                 (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/ALPHA                       (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/DELTA                       (hub-into-instruction-decoder-trigger))
-	     ;;
-	     (* hub.stack/ACC_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/ADD_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/BIN_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/BTC_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/CALL_FLAG                   (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/CON_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/COPY_FLAG                   (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/CREATE_FLAG                 (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/DUP_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/EXT_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/HALT_FLAG                   (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/INVALID_FLAG                (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/JUMP_FLAG                   (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/KEC_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/LOG_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/MACHINE_STATE_FLAG          (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/MOD_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/MUL_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/PUSHPOP_FLAG                (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/SHF_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/STACKRAM_FLAG               (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/STO_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/SWAP_FLAG                   (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/TXN_FLAG                    (hub-into-instruction-decoder-trigger))
-	     (* hub.stack/WCP_FLAG                    (hub-into-instruction-decoder-trigger))
-	     ;;
-           )
+(defclookup hub-into-instdecoder
+  ;; target columns
+  (
+   instdecoder.OPCODE
+   instdecoder.STATIC_GAS
+   instdecoder.TWO_LINE_INSTRUCTION
+   instdecoder.FLAG_1
+   instdecoder.FLAG_2
+   instdecoder.FLAG_3
+   instdecoder.FLAG_4
+   instdecoder.MXP_FLAG
+   instdecoder.STATIC_FLAG
+   instdecoder.ALPHA
+   instdecoder.DELTA
+   ;;
+   instdecoder.FAMILY_ACCOUNT
+   instdecoder.FAMILY_ADD
+   instdecoder.FAMILY_BIN
+   instdecoder.FAMILY_BATCH
+   instdecoder.FAMILY_CALL
+   instdecoder.FAMILY_CONTEXT
+   instdecoder.FAMILY_COPY
+   instdecoder.FAMILY_CREATE
+   instdecoder.FAMILY_DUP
+   instdecoder.FAMILY_EXT
+   instdecoder.FAMILY_HALT
+   instdecoder.FAMILY_INVALID
+   instdecoder.FAMILY_JUMP
+   instdecoder.FAMILY_KEC
+   instdecoder.FAMILY_LOG
+   instdecoder.FAMILY_MACHINE_STATE
+   instdecoder.FAMILY_MOD
+   instdecoder.FAMILY_MUL
+   instdecoder.FAMILY_PUSH_POP
+   instdecoder.FAMILY_SHF
+   instdecoder.FAMILY_STACK_RAM
+   instdecoder.FAMILY_STORAGE
+   instdecoder.FAMILY_SWAP
+   instdecoder.FAMILY_TRANSACTION
+   instdecoder.FAMILY_WCP
+   ;;
+  )
+  ;; source selector
+  (hub-into-instruction-decoder-trigger)
+  ;; source columns
+  (
+   hub.stack/INSTRUCTION
+   hub.stack/STATIC_GAS
+   hub.TWO_LINE_INSTRUCTION
+   [hub.stack/DEC_FLAG 1]
+   [hub.stack/DEC_FLAG 2]
+   [hub.stack/DEC_FLAG 3]
+   [hub.stack/DEC_FLAG 4]
+   hub.stack/MXP_FLAG
+   hub.stack/STATIC_FLAG
+   hub.stack/ALPHA
+   hub.stack/DELTA
+   ;;
+   hub.stack/ACC_FLAG
+   hub.stack/ADD_FLAG
+   hub.stack/BIN_FLAG
+   hub.stack/BTC_FLAG
+   hub.stack/CALL_FLAG
+   hub.stack/CON_FLAG
+   hub.stack/COPY_FLAG
+   hub.stack/CREATE_FLAG
+   hub.stack/DUP_FLAG
+   hub.stack/EXT_FLAG
+   hub.stack/HALT_FLAG
+   hub.stack/INVALID_FLAG
+   hub.stack/JUMP_FLAG
+   hub.stack/KEC_FLAG
+   hub.stack/LOG_FLAG
+   hub.stack/MACHINE_STATE_FLAG
+   hub.stack/MOD_FLAG
+   hub.stack/MUL_FLAG
+   hub.stack/PUSHPOP_FLAG
+   hub.stack/SHF_FLAG
+   hub.stack/STACKRAM_FLAG
+   hub.stack/STO_FLAG
+   hub.stack/SWAP_FLAG
+   hub.stack/TXN_FLAG
+   hub.stack/WCP_FLAG
+   ;;
+   )
 )

--- a/hub/london/lookups/hub_into_log_info.lisp
+++ b/hub/london/lookups/hub_into_log_info.lisp
@@ -1,7 +1,7 @@
 (defun (hub-into-log-info-trigger)
   (* hub.PEEK_AT_STACK hub.stack/LOG_INFO_FLAG (- 1 hub.CT_TLI)))
 
-(deflookup
+(defclookup
   hub-into-loginfo
   ;; target columns
   (
@@ -20,22 +20,24 @@
     [loginfo.TOPIC_LO 4]
     loginfo.DATA_SIZE
   )
+  ;; source selector
+  (hub-into-log-info-trigger)
   ;; source columns
   (
-    (* hub.ABSOLUTE_TRANSACTION_NUMBER (hub-into-log-info-trigger))
-    (* hub.LOG_INFO_STAMP (hub-into-log-info-trigger))
-    (* hub.stack/INSTRUCTION (hub-into-log-info-trigger))
-    (* (shift hub.context/ACCOUNT_ADDRESS_HI 2) (hub-into-log-info-trigger))
-    (* (shift hub.context/ACCOUNT_ADDRESS_LO 2) (hub-into-log-info-trigger))
-    (* (next [hub.stack/STACK_ITEM_VALUE_HI 1]) (hub-into-log-info-trigger))
-    (* (next [hub.stack/STACK_ITEM_VALUE_LO 1]) (hub-into-log-info-trigger))
-    (* (next [hub.stack/STACK_ITEM_VALUE_HI 2]) (hub-into-log-info-trigger))
-    (* (next [hub.stack/STACK_ITEM_VALUE_LO 2]) (hub-into-log-info-trigger))
-    (* (next [hub.stack/STACK_ITEM_VALUE_HI 3]) (hub-into-log-info-trigger))
-    (* (next [hub.stack/STACK_ITEM_VALUE_LO 3]) (hub-into-log-info-trigger))
-    (* (next [hub.stack/STACK_ITEM_VALUE_HI 4]) (hub-into-log-info-trigger))
-    (* (next [hub.stack/STACK_ITEM_VALUE_LO 4]) (hub-into-log-info-trigger))
-    (* [hub.stack/STACK_ITEM_VALUE_LO 2] (hub-into-log-info-trigger))
+    hub.ABSOLUTE_TRANSACTION_NUMBER
+    hub.LOG_INFO_STAMP
+    hub.stack/INSTRUCTION
+    (shift hub.context/ACCOUNT_ADDRESS_HI 2)
+    (shift hub.context/ACCOUNT_ADDRESS_LO 2)
+    (next [hub.stack/STACK_ITEM_VALUE_HI 1])
+    (next [hub.stack/STACK_ITEM_VALUE_LO 1])
+    (next [hub.stack/STACK_ITEM_VALUE_HI 2])
+    (next [hub.stack/STACK_ITEM_VALUE_LO 2])
+    (next [hub.stack/STACK_ITEM_VALUE_HI 3])
+    (next [hub.stack/STACK_ITEM_VALUE_LO 3])
+    (next [hub.stack/STACK_ITEM_VALUE_HI 4])
+    (next [hub.stack/STACK_ITEM_VALUE_LO 4])
+    [hub.stack/STACK_ITEM_VALUE_LO 2]
   ))
 
 

--- a/hub/london/lookups/hub_into_mmu.lisp
+++ b/hub/london/lookups/hub_into_mmu.lisp
@@ -1,7 +1,7 @@
 (defun (hub-into-mmu-trigger)
   (* hub.PEEK_AT_MISCELLANEOUS hub.misc/MMU_FLAG))
 
-(deflookup
+(defclookup
   hub-into-mmu
   ;; target columns
   (
@@ -23,25 +23,27 @@
     mmu.macro/PHASE
     mmu.macro/EXO_SUM
   )
+  ;; source selector
+  (hub-into-mmu-trigger)
   ;; source columns
   (
-    (hub-into-mmu-trigger)
-    (* hub.MMU_STAMP (hub-into-mmu-trigger))
-    (* hub.misc/MMU_INST (hub-into-mmu-trigger))
-    (* hub.misc/MMU_SRC_ID (hub-into-mmu-trigger))
-    (* hub.misc/MMU_TGT_ID (hub-into-mmu-trigger))
-    (* hub.misc/MMU_AUX_ID (hub-into-mmu-trigger))
-    (* hub.misc/MMU_SRC_OFFSET_LO (hub-into-mmu-trigger))
-    (* hub.misc/MMU_SRC_OFFSET_HI (hub-into-mmu-trigger))
-    (* hub.misc/MMU_TGT_OFFSET_LO (hub-into-mmu-trigger))
-    (* hub.misc/MMU_SIZE (hub-into-mmu-trigger))
-    (* hub.misc/MMU_REF_OFFSET (hub-into-mmu-trigger))
-    (* hub.misc/MMU_REF_SIZE (hub-into-mmu-trigger))
-    (* hub.misc/MMU_SUCCESS_BIT (hub-into-mmu-trigger))
-    (* hub.misc/MMU_LIMB_1 (hub-into-mmu-trigger))
-    (* hub.misc/MMU_LIMB_2 (hub-into-mmu-trigger))
-    (* hub.misc/MMU_PHASE (hub-into-mmu-trigger))
-    (* hub.misc/MMU_EXO_SUM (hub-into-mmu-trigger))
+    1
+    hub.MMU_STAMP
+    hub.misc/MMU_INST
+    hub.misc/MMU_SRC_ID
+    hub.misc/MMU_TGT_ID
+    hub.misc/MMU_AUX_ID
+    hub.misc/MMU_SRC_OFFSET_LO
+    hub.misc/MMU_SRC_OFFSET_HI
+    hub.misc/MMU_TGT_OFFSET_LO
+    hub.misc/MMU_SIZE
+    hub.misc/MMU_REF_OFFSET
+    hub.misc/MMU_REF_SIZE
+    hub.misc/MMU_SUCCESS_BIT
+    hub.misc/MMU_LIMB_1
+    hub.misc/MMU_LIMB_2
+    hub.misc/MMU_PHASE
+    hub.misc/MMU_EXO_SUM
   ))
 
 

--- a/hub/london/lookups/hub_into_mod.lisp
+++ b/hub/london/lookups/hub_into_mod.lisp
@@ -2,25 +2,27 @@
   (* (unexceptional-stack-row)
       hub.stack/MOD_FLAG))
 
-(deflookup hub-into-mod
-    ;; target columns
-    (
-        mod.ARG_1_HI
-        mod.ARG_1_LO
-        mod.ARG_2_HI
-        mod.ARG_2_LO
-        mod.RES_HI
-        mod.RES_LO
-        mod.INST
-    )
-    ;; source columns
-    (
-        (* [hub.stack/STACK_ITEM_VALUE_HI 1]     (hub-into-mod-activation-flag))   ;; arg1
-        (* [hub.stack/STACK_ITEM_VALUE_LO 1]     (hub-into-mod-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 2]     (hub-into-mod-activation-flag))   ;; arg2
-        (* [hub.stack/STACK_ITEM_VALUE_LO 2]     (hub-into-mod-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 4]     (hub-into-mod-activation-flag))   ;; res
-        (* [hub.stack/STACK_ITEM_VALUE_LO 4]     (hub-into-mod-activation-flag))
-        (*  hub.stack/INSTRUCTION                (hub-into-mod-activation-flag))
-    )
+(defclookup hub-into-mod
+  ;; target columns
+  (
+   mod.ARG_1_HI
+   mod.ARG_1_LO
+   mod.ARG_2_HI
+   mod.ARG_2_LO
+   mod.RES_HI
+   mod.RES_LO
+   mod.INST
+  )
+  ;; source selector
+  (hub-into-mod-activation-flag)
+  ;; source columns
+  (
+   [hub.stack/STACK_ITEM_VALUE_HI 1]   ;; arg1
+   [hub.stack/STACK_ITEM_VALUE_LO 1]
+   [hub.stack/STACK_ITEM_VALUE_HI 2]   ;; arg2
+   [hub.stack/STACK_ITEM_VALUE_LO 2]
+   [hub.stack/STACK_ITEM_VALUE_HI 4]   ;; res
+   [hub.stack/STACK_ITEM_VALUE_LO 4]
+    hub.stack/INSTRUCTION
+  )
 )

--- a/hub/london/lookups/hub_into_mul.lisp
+++ b/hub/london/lookups/hub_into_mul.lisp
@@ -2,25 +2,27 @@
   (* (unexceptional-stack-row)
       hub.stack/MUL_FLAG))
 
-(deflookup hub-into-mul
-    ;; target columns
-    (
-        mul.ARG_1_HI
-        mul.ARG_1_LO
-        mul.ARG_2_HI
-        mul.ARG_2_LO
-        mul.RES_HI
-        mul.RES_LO
-        mul.INST
-    )
-    ;; source columns
-    (
-        (* [hub.stack/STACK_ITEM_VALUE_HI 1]     (hub-into-mul-activation-flag))   ;; arg1
-        (* [hub.stack/STACK_ITEM_VALUE_LO 1]     (hub-into-mul-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 2]     (hub-into-mul-activation-flag))   ;; arg2
-        (* [hub.stack/STACK_ITEM_VALUE_LO 2]     (hub-into-mul-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 4]     (hub-into-mul-activation-flag))   ;; res
-        (* [hub.stack/STACK_ITEM_VALUE_LO 4]     (hub-into-mul-activation-flag))
-        (*  hub.stack/INSTRUCTION                (hub-into-mul-activation-flag))
-    )
+(defclookup hub-into-mul
+  ;; target columns
+  (
+   mul.ARG_1_HI
+   mul.ARG_1_LO
+   mul.ARG_2_HI
+   mul.ARG_2_LO
+   mul.RES_HI
+   mul.RES_LO
+   mul.INST
+  )
+  ;; source selector
+  (hub-into-mul-activation-flag)
+  ;; source columns
+  (
+   [hub.stack/STACK_ITEM_VALUE_HI 1]   ;; arg1
+   [hub.stack/STACK_ITEM_VALUE_LO 1]
+   [hub.stack/STACK_ITEM_VALUE_HI 2]   ;; arg2
+   [hub.stack/STACK_ITEM_VALUE_LO 2]
+   [hub.stack/STACK_ITEM_VALUE_HI 4]   ;; res
+   [hub.stack/STACK_ITEM_VALUE_LO 4]
+   hub.stack/INSTRUCTION
+ )
 )

--- a/hub/london/lookups/hub_into_mxp.lisp
+++ b/hub/london/lookups/hub_into_mxp.lisp
@@ -1,7 +1,7 @@
 (defun (hub-into-mxp-trigger)
   (* hub.PEEK_AT_MISCELLANEOUS hub.misc/MXP_FLAG))
 
-(deflookup
+(defclookup
   hub-into-mxp
   ;; target columns
   (
@@ -24,24 +24,26 @@
     mxp.SIZE_1_NONZERO_NO_MXPX
     mxp.SIZE_2_NONZERO_NO_MXPX
   )
+  ;; source selector
+  (hub-into-mxp-trigger)
   ;; source columns
   (
-    (* hub.MXP_STAMP                       (hub-into-mxp-trigger))
-    (* hub.CONTEXT_NUMBER                  (hub-into-mxp-trigger))
-    (* hub.misc/MXP_INST                   (hub-into-mxp-trigger))
-    (* hub.misc/MXP_MXPX                   (hub-into-mxp-trigger))
-    (* hub.misc/MXP_DEPLOYS                (hub-into-mxp-trigger))
-    (* hub.misc/MXP_OFFSET_1_HI            (hub-into-mxp-trigger))
-    (* hub.misc/MXP_OFFSET_1_LO            (hub-into-mxp-trigger))
-    (* hub.misc/MXP_OFFSET_2_HI            (hub-into-mxp-trigger))
-    (* hub.misc/MXP_OFFSET_2_LO            (hub-into-mxp-trigger))
-    (* hub.misc/MXP_SIZE_1_HI              (hub-into-mxp-trigger))
-    (* hub.misc/MXP_SIZE_1_LO              (hub-into-mxp-trigger))
-    (* hub.misc/MXP_SIZE_2_HI              (hub-into-mxp-trigger))
-    (* hub.misc/MXP_SIZE_2_LO              (hub-into-mxp-trigger))
-    (* hub.misc/MXP_WORDS                  (hub-into-mxp-trigger))
-    (* hub.misc/MXP_GAS_MXP                (hub-into-mxp-trigger))
-    (* hub.misc/MXP_MTNTOP                 (hub-into-mxp-trigger))
-    (* hub.misc/MXP_SIZE_1_NONZERO_NO_MXPX (hub-into-mxp-trigger))
-    (* hub.misc/MXP_SIZE_2_NONZERO_NO_MXPX (hub-into-mxp-trigger))
+    hub.MXP_STAMP
+    hub.CONTEXT_NUMBER
+    hub.misc/MXP_INST
+    hub.misc/MXP_MXPX
+    hub.misc/MXP_DEPLOYS
+    hub.misc/MXP_OFFSET_1_HI
+    hub.misc/MXP_OFFSET_1_LO
+    hub.misc/MXP_OFFSET_2_HI
+    hub.misc/MXP_OFFSET_2_LO
+    hub.misc/MXP_SIZE_1_HI
+    hub.misc/MXP_SIZE_1_LO
+    hub.misc/MXP_SIZE_2_HI
+    hub.misc/MXP_SIZE_2_LO
+    hub.misc/MXP_WORDS
+    hub.misc/MXP_GAS_MXP
+    hub.misc/MXP_MTNTOP
+    hub.misc/MXP_SIZE_1_NONZERO_NO_MXPX
+    hub.misc/MXP_SIZE_2_NONZERO_NO_MXPX
   ))

--- a/hub/london/lookups/hub_into_oob.lisp
+++ b/hub/london/lookups/hub_into_oob.lisp
@@ -2,7 +2,7 @@
   (* hub.PEEK_AT_MISCELLANEOUS
      hub.misc/OOB_FLAG))
 
-(deflookup hub-into-oob
+(defclookup hub-into-oob
            ;; target columns
 	   (
 	     oob.OOB_INST
@@ -16,17 +16,19 @@
 	     [oob.DATA 8]
 	     [oob.DATA 9]
            )
+           ;; source selector
+           (hub-into-oob-trigger)
            ;; source columns
 	   (
-	     (* hub.misc/OOB_INST               (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 1]           (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 2]           (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 3]           (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 4]           (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 5]           (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 6]           (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 7]           (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 8]           (hub-into-oob-trigger))
-	     (* [hub.misc/OOB_DATA 9]           (hub-into-oob-trigger))
+	     hub.misc/OOB_INST
+	     [hub.misc/OOB_DATA 1]
+	     [hub.misc/OOB_DATA 2]
+	     [hub.misc/OOB_DATA 3]
+	     [hub.misc/OOB_DATA 4]
+	     [hub.misc/OOB_DATA 5]
+	     [hub.misc/OOB_DATA 6]
+	     [hub.misc/OOB_DATA 7]
+	     [hub.misc/OOB_DATA 8]
+	     [hub.misc/OOB_DATA 9]
            )
 )

--- a/hub/london/lookups/hub_into_rlp_addr.lisp
+++ b/hub/london/lookups/hub_into_rlp_addr.lisp
@@ -3,31 +3,33 @@
      hub.account/RLPADDR_FLAG))
 
 ;;
-(deflookup hub-into-rlpaddr
-           ;; target columns
-	   (
-	     rlpaddr.RECIPE
-	     rlpaddr.ADDR_HI
-	     rlpaddr.ADDR_LO
-	     rlpaddr.NONCE
-	     rlpaddr.DEP_ADDR_HI
-	     rlpaddr.DEP_ADDR_LO
-	     rlpaddr.SALT_HI
-	     rlpaddr.SALT_LO
-	     rlpaddr.KEC_HI
-	     rlpaddr.KEC_LO
-           )
-           ;; source columns
-	   (
-	     (* hub.account/RLPADDR_RECIPE                         (hub-into-rlp-addr-trigger))
-	     (* hub.account/ADDRESS_HI                             (hub-into-rlp-addr-trigger))
-	     (* hub.account/ADDRESS_LO                             (hub-into-rlp-addr-trigger))
-	     (* hub.account/NONCE                                  (hub-into-rlp-addr-trigger))
-	     (* hub.account/RLPADDR_DEP_ADDR_HI                    (hub-into-rlp-addr-trigger))
-	     (* hub.account/RLPADDR_DEP_ADDR_LO                    (hub-into-rlp-addr-trigger))
-	     (* hub.account/RLPADDR_SALT_HI                        (hub-into-rlp-addr-trigger))
-	     (* hub.account/RLPADDR_SALT_LO                        (hub-into-rlp-addr-trigger))
-	     (* hub.account/RLPADDR_KEC_HI                         (hub-into-rlp-addr-trigger))
-	     (* hub.account/RLPADDR_KEC_LO                         (hub-into-rlp-addr-trigger))
-           )
+(defclookup hub-into-rlpaddr
+  ;; target columns
+  (
+   rlpaddr.RECIPE
+   rlpaddr.ADDR_HI
+   rlpaddr.ADDR_LO
+   rlpaddr.NONCE
+   rlpaddr.DEP_ADDR_HI
+   rlpaddr.DEP_ADDR_LO
+   rlpaddr.SALT_HI
+   rlpaddr.SALT_LO
+   rlpaddr.KEC_HI
+   rlpaddr.KEC_LO
+  )
+  ;; source selector
+  (hub-into-rlp-addr-trigger)
+  ;; source columns
+  (
+   hub.account/RLPADDR_RECIPE
+   hub.account/ADDRESS_HI
+   hub.account/ADDRESS_LO
+   hub.account/NONCE
+   hub.account/RLPADDR_DEP_ADDR_HI
+   hub.account/RLPADDR_DEP_ADDR_LO
+   hub.account/RLPADDR_SALT_HI
+   hub.account/RLPADDR_SALT_LO
+   hub.account/RLPADDR_KEC_HI
+   hub.account/RLPADDR_KEC_LO
+  )
 )

--- a/hub/london/lookups/hub_into_rlp_txn.lisp
+++ b/hub/london/lookups/hub_into_rlp_txn.lisp
@@ -14,30 +14,37 @@
                                               rlptxn.IS_PHASE_ACCESS_LIST
                                               (- 1 rlptxn.IS_PREFIX)))
 
-(deflookup
+(defclookup
   hub-into-rlptxn
+  ;; TODO: target selector likely unnecessary but as we multiply by
+  ;; the same column for the lookup tlptxn into hub ...
+    
+  ;; target selector
+  (hub-into-rlp-txn-tgt-selector)
   ;; target columns
-  ;; TODO: multiplication by selector likely unnecessary but as we multiply by the same column for the lookup tlptxn into hub ...
   (
-    (* 1                                    (hub-into-rlp-txn-tgt-selector))
-    (* rlptxn.ABS_TX_NUM                    (hub-into-rlp-txn-tgt-selector))
-    (* (- 1 (rlp-txn-depth-2))              (hub-into-rlp-txn-tgt-selector))
-    (* (rlp-txn-depth-2)                    (hub-into-rlp-txn-tgt-selector))
+    1
+    rlptxn.ABS_TX_NUM
+    (- 1 (rlp-txn-depth-2))
+    (rlp-txn-depth-2)
 
-    (* rlptxn.ADDR_HI                       (hub-into-rlp-txn-tgt-selector))
-    (* rlptxn.ADDR_LO                       (hub-into-rlp-txn-tgt-selector))
-    (* [rlptxn.INPUT 1] (rlp-txn-depth-2)   (hub-into-rlp-txn-tgt-selector))
-    (* [rlptxn.INPUT 2] (rlp-txn-depth-2)   (hub-into-rlp-txn-tgt-selector)) ;; ""
+    rlptxn.ADDR_HI
+    rlptxn.ADDR_LO
+    (* [rlptxn.INPUT 1] (rlp-txn-depth-2))
+    (* [rlptxn.INPUT 2] (rlp-txn-depth-2))
   )
+  ;; source selector
+  (hub-into-rlp-txn-src-selector)
   ;; source columns
   (
-    (* 1                                    (hub-into-rlp-txn-src-selector))
-    (* hub.ABSOLUTE_TRANSACTION_NUMBER      (hub-into-rlp-txn-src-selector))
-    (* hub.PEEK_AT_ACCOUNT                  (hub-into-rlp-txn-src-selector))
-    (* hub.PEEK_AT_STORAGE                  (hub-into-rlp-txn-src-selector))
+    1
+    hub.ABSOLUTE_TRANSACTION_NUMBER
+    hub.PEEK_AT_ACCOUNT
+    hub.PEEK_AT_STORAGE
 
-    (* (prewarming-phase-address-hi)        (hub-into-rlp-txn-src-selector))
-    (* (prewarming-phase-address-lo)        (hub-into-rlp-txn-src-selector))
-    (* (prewarming-phase-storage-key-hi)    (hub-into-rlp-txn-src-selector))
-    (* (prewarming-phase-storage-key-lo)    (hub-into-rlp-txn-src-selector))
-  ))
+    (prewarming-phase-address-hi)
+    (prewarming-phase-address-lo)
+    (prewarming-phase-storage-key-hi)
+    (prewarming-phase-storage-key-lo)
+  )
+)

--- a/hub/london/lookups/hub_into_rom_instruction_fetching.lisp
+++ b/hub/london/lookups/hub_into_rom_instruction_fetching.lisp
@@ -1,20 +1,22 @@
 (defun (hub-into-rom-instruction-fetching-trigger) hub.PEEK_AT_STACK)
 
-(deflookup hub-into-rom-instruction-fetching
-           ;; target columns
-	   (
-	     rom.CFI
-	     rom.PC
-	     rom.OPCODE
-	     rom.PUSH_VALUE_HI
-	     rom.PUSH_VALUE_LO
-           )
-           ;; source columns
-	   (
-	     (* hub.CFI                    (hub-into-rom-instruction-fetching-trigger))
-	     (* hub.PC                     (hub-into-rom-instruction-fetching-trigger))
-	     (* hub.stack/INSTRUCTION      (hub-into-rom-instruction-fetching-trigger))
-	     (* hub.stack/PUSH_VALUE_HI    (hub-into-rom-instruction-fetching-trigger))
-	     (* hub.stack/PUSH_VALUE_LO    (hub-into-rom-instruction-fetching-trigger))
-           )
+(defclookup hub-into-rom-instruction-fetching
+  ;; target columns
+  (
+   rom.CFI
+   rom.PC
+   rom.OPCODE
+   rom.PUSH_VALUE_HI
+   rom.PUSH_VALUE_LO
+  )
+  ;; source selector
+  (hub-into-rom-instruction-fetching-trigger)
+  ;; source columns
+  (
+   hub.CFI
+   hub.PC
+   hub.stack/INSTRUCTION
+   hub.stack/PUSH_VALUE_HI
+   hub.stack/PUSH_VALUE_LO
+  )
 )

--- a/hub/london/lookups/hub_into_rom_jump_destination_vetting.lisp
+++ b/hub/london/lookups/hub_into_rom_jump_destination_vetting.lisp
@@ -2,17 +2,19 @@
   (* hub.PEEK_AT_STACK
      hub.stack/JUMP_DESTINATION_VETTING_REQUIRED))
 
-(deflookup hub-into-rom-jump-destination-vetting
-           ;; target columns
-	   (
-	     rom.CFI
-	     rom.PC
-	     rom.IS_JUMPDEST
-           )
-           ;; source columns
-	   (
-	     (* hub.CFI                                (hub-into-rom-jump-destination-vetting-trigger))
-	     (* [hub.stack/STACK_ITEM_VALUE_LO 1]      (hub-into-rom-jump-destination-vetting-trigger))
-	     (* (- 1 hub.stack/JUMPX)                  (hub-into-rom-jump-destination-vetting-trigger))
-           )
+(defclookup hub-into-rom-jump-destination-vetting
+  ;; target columns
+  (
+   rom.CFI
+   rom.PC
+   rom.IS_JUMPDEST
+  )
+  ;; source selector
+  (hub-into-rom-jump-destination-vetting-trigger)
+  ;; source columns
+  (
+   hub.CFI
+   [hub.stack/STACK_ITEM_VALUE_LO 1]
+   (- 1 hub.stack/JUMPX)
+  )
 )

--- a/hub/london/lookups/hub_into_rom_lex.lisp
+++ b/hub/london/lookups/hub_into_rom_lex.lisp
@@ -3,27 +3,29 @@
      hub.account/ROMLEX_FLAG))
 
 
-(deflookup hub-into-romlex
-           ;; target columns
-	   (
-	     romlex.CODE_FRAGMENT_INDEX
-	     romlex.CODE_SIZE
-	     romlex.ADDRESS_HI
-	     romlex.ADDRESS_LO
-	     romlex.DEPLOYMENT_NUMBER
-	     romlex.DEPLOYMENT_STATUS
-	     romlex.CODE_HASH_HI
-	     romlex.CODE_HASH_LO
-           )
-           ;; source columns
-	   (
-	     (* hub.account/CODE_FRAGMENT_INDEX      (hub-into-rom-lex-trigger))
-	     (* hub.account/CODE_SIZE_NEW            (hub-into-rom-lex-trigger))
-	     (* hub.account/ADDRESS_HI               (hub-into-rom-lex-trigger))
-	     (* hub.account/ADDRESS_LO               (hub-into-rom-lex-trigger))
-	     (* hub.account/DEPLOYMENT_NUMBER_NEW    (hub-into-rom-lex-trigger))
-	     (* hub.account/DEPLOYMENT_STATUS_NEW    (hub-into-rom-lex-trigger))
-	     (* hub.account/CODE_HASH_HI_NEW         (hub-into-rom-lex-trigger))
-	     (* hub.account/CODE_HASH_LO_NEW         (hub-into-rom-lex-trigger))
-           )
+(defclookup hub-into-romlex
+  ;; target columns
+  (
+   romlex.CODE_FRAGMENT_INDEX
+   romlex.CODE_SIZE
+   romlex.ADDRESS_HI
+   romlex.ADDRESS_LO
+   romlex.DEPLOYMENT_NUMBER
+   romlex.DEPLOYMENT_STATUS
+   romlex.CODE_HASH_HI
+   romlex.CODE_HASH_LO
+  )
+  ;; source selector
+  (hub-into-rom-lex-trigger)
+  ;; source columns
+  (
+   hub.account/CODE_FRAGMENT_INDEX
+   hub.account/CODE_SIZE_NEW
+   hub.account/ADDRESS_HI
+   hub.account/ADDRESS_LO
+   hub.account/DEPLOYMENT_NUMBER_NEW
+   hub.account/DEPLOYMENT_STATUS_NEW
+   hub.account/CODE_HASH_HI_NEW
+   hub.account/CODE_HASH_LO_NEW
+   )
 )

--- a/hub/london/lookups/hub_into_shakira.lisp
+++ b/hub/london/lookups/hub_into_shakira.lisp
@@ -3,21 +3,23 @@
     hub.PEEK_AT_STACK
     hub.stack/HASH_INFO_FLAG))
 
-(deflookup hub-into-shakiradata
-	   ;; target columns
-	   (
-	     shakiradata.PHASE
-	     shakiradata.ID
-	     shakiradata.INDEX
-	     (shift shakiradata.LIMB -1)
-	     shakiradata.LIMB
-	     )
-	   ;; source columns
-	   (
-	    (* PHASE_KECCAK_RESULT            (hub-into-shakira-trigger))
-	    (* (+ 1 hub.HUB_STAMP)            (hub-into-shakira-trigger))
-	    (* 1                              (hub-into-shakira-trigger)) ;; we could just write (hub-into-shakira-trigger)
-	    (* hub.stack/HASH_INFO_KECCAK_HI     (hub-into-shakira-trigger))
-	    (* hub.stack/HASH_INFO_KECCAK_LO     (hub-into-shakira-trigger))
-	    )
-	   )
+(defclookup hub-into-shakiradata
+  ;; target columns
+  (
+   shakiradata.PHASE
+   shakiradata.ID
+   shakiradata.INDEX
+   (shift shakiradata.LIMB -1)
+   shakiradata.LIMB
+  )
+  ;; source selector
+  (hub-into-shakira-trigger)
+  ;; source columns
+  (
+   PHASE_KECCAK_RESULT
+   (+ 1 hub.HUB_STAMP)
+   1
+   hub.stack/HASH_INFO_KECCAK_HI
+   hub.stack/HASH_INFO_KECCAK_LO
+  )
+)

--- a/hub/london/lookups/hub_into_shf.lisp
+++ b/hub/london/lookups/hub_into_shf.lisp
@@ -2,25 +2,27 @@
   (* (unexceptional-stack-row)
       hub.stack/SHF_FLAG))
 
-(deflookup hub-into-shf
-    ;; target columns
-    (
-        shf.ARG_1_HI
-        shf.ARG_1_LO
-        shf.ARG_2_HI
-        shf.ARG_2_LO
-        shf.RES_HI
-        shf.RES_LO
-        shf.INST
-    )
-    ;; source columns
-    (
-        (* [hub.stack/STACK_ITEM_VALUE_HI 1]     (hub-into-shf-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 1]     (hub-into-shf-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 2]     (hub-into-shf-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 2]     (hub-into-shf-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 4]     (hub-into-shf-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 4]     (hub-into-shf-activation-flag))
-        (*  hub.stack/INSTRUCTION                (hub-into-shf-activation-flag))
-    )
+(defclookup hub-into-shf
+  ;; target columns
+  (
+   shf.ARG_1_HI
+   shf.ARG_1_LO
+   shf.ARG_2_HI
+   shf.ARG_2_LO
+   shf.RES_HI
+   shf.RES_LO
+   shf.INST
+  )
+  ;; source selector
+  (hub-into-shf-activation-flag)
+  ;; source columns
+  (
+   [hub.stack/STACK_ITEM_VALUE_HI 1]
+   [hub.stack/STACK_ITEM_VALUE_LO 1]
+   [hub.stack/STACK_ITEM_VALUE_HI 2]
+   [hub.stack/STACK_ITEM_VALUE_LO 2]
+   [hub.stack/STACK_ITEM_VALUE_HI 4]
+   [hub.stack/STACK_ITEM_VALUE_LO 4]
+   hub.stack/INSTRUCTION
+  )
 )

--- a/hub/london/lookups/hub_into_stp.lisp
+++ b/hub/london/lookups/hub_into_stp.lisp
@@ -1,7 +1,7 @@
 (defun (hub-into-stp-trigger)
   (* hub.PEEK_AT_MISCELLANEOUS hub.misc/STP_FLAG))
 
-(deflookup
+(defclookup
   hub-into-stp
   ;; target columns
   (
@@ -19,21 +19,23 @@
     stp.GAS_OUT_OF_POCKET
     stp.GAS_STIPEND
   )
+  ;; source selector
+  (hub-into-stp-trigger)
   ;; source columns
   (
-    (* hub.misc/STP_INSTRUCTION            (hub-into-stp-trigger))
-    (* hub.misc/STP_GAS_HI                 (hub-into-stp-trigger))
-    (* hub.misc/STP_GAS_LO                 (hub-into-stp-trigger))
-    (* hub.misc/STP_VALUE_HI               (hub-into-stp-trigger))
-    (* hub.misc/STP_VALUE_LO               (hub-into-stp-trigger))
-    (* hub.misc/STP_EXISTS                 (hub-into-stp-trigger))
-    (* hub.misc/STP_WARMTH                 (hub-into-stp-trigger))
-    (* hub.misc/STP_OOGX                   (hub-into-stp-trigger))
-    (* hub.GAS_ACTUAL                      (hub-into-stp-trigger))
-    (* hub.misc/STP_GAS_UPFRONT_GAS_COST   (hub-into-stp-trigger))
-    (* hub.misc/STP_GAS_MXP                (hub-into-stp-trigger))
-    (* hub.misc/STP_GAS_PAID_OUT_OF_POCKET (hub-into-stp-trigger))
-    (* hub.misc/STP_GAS_STIPEND            (hub-into-stp-trigger))
+    hub.misc/STP_INSTRUCTION
+    hub.misc/STP_GAS_HI
+    hub.misc/STP_GAS_LO
+    hub.misc/STP_VALUE_HI
+    hub.misc/STP_VALUE_LO
+    hub.misc/STP_EXISTS
+    hub.misc/STP_WARMTH
+    hub.misc/STP_OOGX
+    hub.GAS_ACTUAL
+    hub.misc/STP_GAS_UPFRONT_GAS_COST
+    hub.misc/STP_GAS_MXP
+    hub.misc/STP_GAS_PAID_OUT_OF_POCKET
+    hub.misc/STP_GAS_STIPEND
   )
   )
 

--- a/hub/london/lookups/hub_into_trm.lisp
+++ b/hub/london/lookups/hub_into_trm.lisp
@@ -2,19 +2,21 @@
   (* hub.PEEK_AT_ACCOUNT
      hub.account/TRM_FLAG))
 
-(deflookup hub-into-trm
-           ;; target columns
-           (
-             trm.TRM_ADDRESS_HI
-             trm.RAW_ADDRESS_HI
-             trm.RAW_ADDRESS_LO
-             trm.IS_PRECOMPILE
-             )
-           ;; source columns
-           (
-            (* hub.account/ADDRESS_HI                    (hub-into-trm-trigger))
-            (* hub.account/TRM_RAW_ADDRESS_HI            (hub-into-trm-trigger))
-            (* hub.account/ADDRESS_LO                    (hub-into-trm-trigger))
-            (* hub.account/IS_PRECOMPILE                 (hub-into-trm-trigger))
-            )
-           )
+(defclookup hub-into-trm
+  ;; target columns
+  (
+   trm.TRM_ADDRESS_HI
+   trm.RAW_ADDRESS_HI
+   trm.RAW_ADDRESS_LO
+   trm.IS_PRECOMPILE
+  )
+  ;; source selector
+  (hub-into-trm-trigger)
+  ;; source columns
+  (
+   hub.account/ADDRESS_HI
+   hub.account/TRM_RAW_ADDRESS_HI
+   hub.account/ADDRESS_LO
+   hub.account/IS_PRECOMPILE
+  )
+)

--- a/hub/london/lookups/hub_into_txn_data.lisp
+++ b/hub/london/lookups/hub_into_txn_data.lisp
@@ -1,66 +1,68 @@
 (defun (hub-into-txn-data-trigger) hub.PEEK_AT_TRANSACTION)
 
-(deflookup hub-into-txndata
-           ;; target columns
-           (
-            txndata.ABS_TX_NUM
-            txndata.REL_BLOCK
-            txndata.FROM_HI
-            txndata.FROM_LO
-            txndata.TO_HI
-            txndata.TO_LO
-            txndata.COINBASE_HI
-            txndata.COINBASE_LO
-            ;;
-            txndata.NONCE
-            txndata.VALUE
-            txndata.IS_DEP
-            txndata.TYPE2
-            txndata.GAS_PRICE
-            txndata.GAS_LIMIT
-            txndata.PRIORITY_FEE_PER_GAS
-            txndata.BASEFEE
-            txndata.CALL_DATA_SIZE
-            txndata.INIT_CODE_SIZE
-            ;;
-            txndata.GAS_INITIALLY_AVAILABLE
-            txndata.INITIAL_BALANCE
-            txndata.REQUIRES_EVM_EXECUTION
-            txndata.COPY_TXCD
-            txndata.STATUS_CODE
-            txndata.GAS_LEFTOVER
-            txndata.REFUND_COUNTER
-            txndata.REFUND_EFFECTIVE
-            )
-           ;; source columns
-           (
-            (* hub.ABSOLUTE_TRANSACTION_NUMBER                                      (hub-into-txn-data-trigger))
-            (* hub.RELATIVE_BLOCK_NUMBER                                            (hub-into-txn-data-trigger))
-            (* hub.transaction/FROM_ADDRESS_HI                                      (hub-into-txn-data-trigger))
-            (* hub.transaction/FROM_ADDRESS_LO                                      (hub-into-txn-data-trigger))
-            (* hub.transaction/TO_ADDRESS_HI                                        (hub-into-txn-data-trigger))
-            (* hub.transaction/TO_ADDRESS_LO                                        (hub-into-txn-data-trigger))
-            (* hub.transaction/COINBASE_ADDRESS_HI                                  (hub-into-txn-data-trigger))
-            (* hub.transaction/COINBASE_ADDRESS_LO                                  (hub-into-txn-data-trigger))
-            ;;
-            (* hub.transaction/NONCE                                                (hub-into-txn-data-trigger))
-            (* hub.transaction/VALUE                                                (hub-into-txn-data-trigger))
-            (* hub.transaction/IS_DEPLOYMENT                                        (hub-into-txn-data-trigger))
-            (* hub.transaction/IS_TYPE2                                             (hub-into-txn-data-trigger))
-            (* hub.transaction/GAS_PRICE                                            (hub-into-txn-data-trigger))
-            (* hub.transaction/GAS_LIMIT                                            (hub-into-txn-data-trigger))
-            (* hub.transaction/PRIORITY_FEE_PER_GAS                                 (hub-into-txn-data-trigger))
-            (* hub.transaction/BASEFEE                                              (hub-into-txn-data-trigger))
-            (* hub.transaction/CALL_DATA_SIZE                                       (hub-into-txn-data-trigger))
-            (* hub.transaction/INIT_CODE_SIZE                                       (hub-into-txn-data-trigger))
-            ;;
-            (* hub.transaction/GAS_INITIALLY_AVAILABLE                              (hub-into-txn-data-trigger))
-            (* hub.transaction/INITIAL_BALANCE                                      (hub-into-txn-data-trigger))
-            (* hub.transaction/REQUIRES_EVM_EXECUTION                               (hub-into-txn-data-trigger))
-            (* hub.transaction/COPY_TXCD                                            (hub-into-txn-data-trigger))
-            (* hub.transaction/STATUS_CODE                                          (hub-into-txn-data-trigger))
-            (* hub.transaction/GAS_LEFTOVER                                         (hub-into-txn-data-trigger))
-            (* hub.transaction/REFUND_COUNTER_INFINITY                              (hub-into-txn-data-trigger))
-            (* hub.transaction/REFUND_EFFECTIVE                                     (hub-into-txn-data-trigger))
-            )
-           )
+(defclookup hub-into-txndata
+  ;; target columns
+  (
+   txndata.ABS_TX_NUM
+   txndata.REL_BLOCK
+   txndata.FROM_HI
+   txndata.FROM_LO
+   txndata.TO_HI
+   txndata.TO_LO
+   txndata.COINBASE_HI
+   txndata.COINBASE_LO
+   ;;
+   txndata.NONCE
+   txndata.VALUE
+   txndata.IS_DEP
+   txndata.TYPE2
+   txndata.GAS_PRICE
+   txndata.GAS_LIMIT
+   txndata.PRIORITY_FEE_PER_GAS
+   txndata.BASEFEE
+   txndata.CALL_DATA_SIZE
+   txndata.INIT_CODE_SIZE
+   ;;
+   txndata.GAS_INITIALLY_AVAILABLE
+   txndata.INITIAL_BALANCE
+   txndata.REQUIRES_EVM_EXECUTION
+   txndata.COPY_TXCD
+   txndata.STATUS_CODE
+   txndata.GAS_LEFTOVER
+   txndata.REFUND_COUNTER
+   txndata.REFUND_EFFECTIVE
+  )
+  ;; source selector
+  (hub-into-txn-data-trigger)
+  ;; source columns
+  (
+   hub.ABSOLUTE_TRANSACTION_NUMBER
+   hub.RELATIVE_BLOCK_NUMBER
+   hub.transaction/FROM_ADDRESS_HI
+   hub.transaction/FROM_ADDRESS_LO
+   hub.transaction/TO_ADDRESS_HI
+   hub.transaction/TO_ADDRESS_LO
+   hub.transaction/COINBASE_ADDRESS_HI
+   hub.transaction/COINBASE_ADDRESS_LO
+   ;;
+   hub.transaction/NONCE
+   hub.transaction/VALUE
+   hub.transaction/IS_DEPLOYMENT
+   hub.transaction/IS_TYPE2
+   hub.transaction/GAS_PRICE
+   hub.transaction/GAS_LIMIT
+   hub.transaction/PRIORITY_FEE_PER_GAS
+   hub.transaction/BASEFEE
+   hub.transaction/CALL_DATA_SIZE
+   hub.transaction/INIT_CODE_SIZE
+   ;;
+   hub.transaction/GAS_INITIALLY_AVAILABLE
+   hub.transaction/INITIAL_BALANCE
+   hub.transaction/REQUIRES_EVM_EXECUTION
+   hub.transaction/COPY_TXCD
+   hub.transaction/STATUS_CODE
+   hub.transaction/GAS_LEFTOVER
+   hub.transaction/REFUND_COUNTER_INFINITY
+   hub.transaction/REFUND_EFFECTIVE
+  )
+)

--- a/hub/london/lookups/hub_into_wcp.lisp
+++ b/hub/london/lookups/hub_into_wcp.lisp
@@ -2,7 +2,7 @@
   (* (unexceptional-stack-row)
       hub.stack/WCP_FLAG))
 
-(deflookup hub-into-wcp
+(defclookup hub-into-wcp
     ;; target columns
     (
         wcp.ARG_1_HI
@@ -12,13 +12,15 @@
         wcp.RESULT
         wcp.INST
     )
+    ;; source selector
+    (hub-into-wcp-activation-flag)
     ;; source columns
     (
-        (* [hub.stack/STACK_ITEM_VALUE_HI 1]     (hub-into-wcp-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 1]     (hub-into-wcp-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_HI 2]     (hub-into-wcp-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 2]     (hub-into-wcp-activation-flag))
-        (* [hub.stack/STACK_ITEM_VALUE_LO 4]     (hub-into-wcp-activation-flag))
-        (* hub.stack/INSTRUCTION                 (hub-into-wcp-activation-flag))
+        [hub.stack/STACK_ITEM_VALUE_HI 1]
+        [hub.stack/STACK_ITEM_VALUE_LO 1]
+        [hub.stack/STACK_ITEM_VALUE_HI 2]
+        [hub.stack/STACK_ITEM_VALUE_LO 2]
+        [hub.stack/STACK_ITEM_VALUE_LO 4]
+        hub.stack/INSTRUCTION
     )
 )

--- a/hub/london/lookups/hub_into_wcp_for_stack_overflow.lisp
+++ b/hub/london/lookups/hub_into_wcp_for_stack_overflow.lisp
@@ -4,7 +4,7 @@
 (defun (projected-height)
   (- (+ hub.HEIGHT hub.stack/ALPHA) hub.stack/DELTA))
 
-(deflookup
+(defclookup
   hub-into-wcp-for-sox
   ;; target columns
   (
@@ -15,14 +15,16 @@
     wcp.ARG_2_LO
     wcp.RESULT
   )
+  ;; source selector
+  (hub-into-wcp-for-sox-activation-flag)
   ;; source columns
   (
-    (* EVM_INST_GT (hub-into-wcp-for-sox-activation-flag))
+    EVM_INST_GT
     0
-    (* (projected-height) (hub-into-wcp-for-sox-activation-flag))
+    (projected-height)
     0
-    (* 1024 (hub-into-wcp-for-sox-activation-flag))
-    (* hub.stack/SOX (hub-into-wcp-for-sox-activation-flag))
+    1024
+    hub.stack/SOX
   ))
 
 

--- a/hub/london/lookups/hub_into_wcp_for_stack_underflow.lisp
+++ b/hub/london/lookups/hub_into_wcp_for_stack_underflow.lisp
@@ -1,6 +1,6 @@
 (defun (hub-into-wcp-for-sux-activation-flag) hub.PEEK_AT_STACK)
 
-(deflookup hub-into-wcp-for-sux
+(defclookup hub-into-wcp-for-sux
     ;; target columns
     (
         wcp.INST
@@ -10,13 +10,15 @@
         wcp.ARG_2_LO
         wcp.RESULT
     )
+    ;; source selector
+    (hub-into-wcp-for-sux-activation-flag)
     ;; source columns
     (
-        (* EVM_INST_LT         (hub-into-wcp-for-sux-activation-flag))
+        EVM_INST_LT
         0
-        (* hub.HEIGHT          (hub-into-wcp-for-sux-activation-flag))
+        hub.HEIGHT
         0
-        (* hub.stack/DELTA     (hub-into-wcp-for-sux-activation-flag))
-        (* hub.stack/SUX       (hub-into-wcp-for-sux-activation-flag))
+        hub.stack/DELTA
+        hub.stack/SUX
     )
 )

--- a/logdata/lookups/logdata-to-rlprcpt.lisp
+++ b/logdata/lookups/logdata-to-rlprcpt.lisp
@@ -1,9 +1,9 @@
 (defun (sel-logdata-to-rlptxnrcpt)
   logdata.LOGS_DATA)
 
-(deflookup
+(defclookup
   logdata-into-rlptxnrcpt
-  ;reference columns
+  ;; target columns
   (
     rlptxrcpt.ABS_LOG_NUM
     rlptxrcpt.PHASE_ID
@@ -11,13 +11,15 @@
     rlptxrcpt.LIMB
     rlptxrcpt.nBYTES
   )
-  ;source columns
+  ;; source selector
+  (sel-logdata-to-rlptxnrcpt)
+  ;; source columns
   (
-    (* logdata.ABS_LOG_NUM            (sel-logdata-to-rlptxnrcpt))
-    (* RLP_RCPT_SUBPHASE_ID_DATA_LIMB (sel-logdata-to-rlptxnrcpt))
-    (* logdata.INDEX                  (sel-logdata-to-rlptxnrcpt))
-    (* logdata.LIMB                   (sel-logdata-to-rlptxnrcpt))
-    (* logdata.SIZE_LIMB              (sel-logdata-to-rlptxnrcpt))
+    logdata.ABS_LOG_NUM
+    RLP_RCPT_SUBPHASE_ID_DATA_LIMB
+    logdata.INDEX
+    logdata.LIMB
+    logdata.SIZE_LIMB
   ))
 
 

--- a/loginfo/lookups/loginfo-into-logdata.lisp
+++ b/loginfo/lookups/loginfo-into-logdata.lisp
@@ -1,7 +1,7 @@
 (defun (sel-loginfo-to-logdata)
   loginfo.TXN_EMITS_LOGS)
 
-(deflookup
+(defclookup
   loginfo-into-logdata
   ;; target columns
   (
@@ -9,11 +9,13 @@
     logdata.ABS_LOG_NUM
     logdata.SIZE_TOTAL
   )
+  ;; source selector
+  (sel-loginfo-to-logdata)
   ;; source columns
   (
-    (* loginfo.ABS_LOG_NUM_MAX (sel-loginfo-to-logdata))
-    (* loginfo.ABS_LOG_NUM (sel-loginfo-to-logdata))
-    (* loginfo.DATA_SIZE (sel-loginfo-to-logdata))
+    loginfo.ABS_LOG_NUM_MAX
+    loginfo.ABS_LOG_NUM
+    loginfo.DATA_SIZE
   ))
 
 

--- a/mmio/lookups/mmio_into_blakemodexp.lisp
+++ b/mmio/lookups/mmio_into_blakemodexp.lisp
@@ -1,18 +1,20 @@
-(deflookup
+(defclookup
   mmio-into-blake2fmodexpdata
-  ;reference columns
+  ;; target columns
   (
     blake2fmodexpdata.ID
     blake2fmodexpdata.PHASE
     blake2fmodexpdata.INDEX
     blake2fmodexpdata.LIMB
   )
-  ;source columns
+  ;; source selector
+  mmio.EXO_IS_BLAKEMODEXP 
+  ;; source columns
   (
-    (* mmio.EXO_IS_BLAKEMODEXP mmio.EXO_ID)
-    (* mmio.EXO_IS_BLAKEMODEXP mmio.PHASE)
-    (* mmio.EXO_IS_BLAKEMODEXP mmio.INDEX_X)
-    (* mmio.EXO_IS_BLAKEMODEXP mmio.LIMB)
+    mmio.EXO_ID
+    mmio.PHASE
+    mmio.INDEX_X
+    mmio.LIMB
   ))
 
 

--- a/mmio/lookups/mmio_into_ecdata.lisp
+++ b/mmio/lookups/mmio_into_ecdata.lisp
@@ -1,6 +1,6 @@
-(deflookup
+(defclookup
   mmio-into-ecdata
-  ;reference columns
+  ;; target columns
   (
     ecdata.ID
     ecdata.PHASE
@@ -9,14 +9,16 @@
     ecdata.TOTAL_SIZE
     ecdata.SUCCESS_BIT
   )
-  ;source columns
+  ;; source selector
+  mmio.EXO_IS_ECDATA
+  ;; source columns
   (
-    (* mmio.EXO_IS_ECDATA mmio.EXO_ID)
-    (* mmio.EXO_IS_ECDATA mmio.PHASE)
-    (* mmio.EXO_IS_ECDATA mmio.INDEX_X)
-    (* mmio.EXO_IS_ECDATA mmio.LIMB)
-    (* mmio.EXO_IS_ECDATA mmio.TOTAL_SIZE)
-    (* mmio.EXO_IS_ECDATA mmio.SUCCESS_BIT)
+    mmio.EXO_ID
+    mmio.PHASE
+    mmio.INDEX_X
+    mmio.LIMB
+    mmio.TOTAL_SIZE
+    mmio.SUCCESS_BIT
   ))
 
 

--- a/mmio/lookups/mmio_into_kec.lisp
+++ b/mmio/lookups/mmio_into_kec.lisp
@@ -1,6 +1,6 @@
-(deflookup
+(defclookup
   mmio-into-kec
-  ;reference columns
+  ;; target columns
   (
     shakiradata.ID
     shakiradata.PHASE
@@ -9,14 +9,16 @@
     shakiradata.nBYTES
     shakiradata.TOTAL_SIZE
   )
-  ;source columns
+  ;; source selector
+  mmio.EXO_IS_KEC
+  ;; source columns
   (
-    (* mmio.EXO_IS_KEC mmio.KEC_ID)
-    (* mmio.EXO_IS_KEC PHASE_KECCAK_DATA)
-    (* mmio.EXO_IS_KEC mmio.INDEX_X)
-    (* mmio.EXO_IS_KEC mmio.LIMB)
-    (* mmio.EXO_IS_KEC mmio.SIZE)
-    (* mmio.EXO_IS_KEC mmio.TOTAL_SIZE)
+    mmio.KEC_ID
+    PHASE_KECCAK_DATA
+    mmio.INDEX_X
+    mmio.LIMB
+    mmio.SIZE
+    mmio.TOTAL_SIZE
   ))
 
 

--- a/mmio/lookups/mmio_into_logdata.lisp
+++ b/mmio/lookups/mmio_into_logdata.lisp
@@ -1,6 +1,6 @@
-(deflookup
+(defclookup
   mmio-into-logdata
-  ;reference columns
+  ;; target columns
   (
     logdata.ABS_LOG_NUM
     logdata.INDEX
@@ -8,13 +8,15 @@
     logdata.SIZE_LIMB
     logdata.SIZE_TOTAL
   )
-  ;source columns
+  ;; source selector
+  mmio.EXO_IS_LOG
+  ;; source columns
   (
-    (* mmio.EXO_IS_LOG mmio.EXO_ID)
-    (* mmio.EXO_IS_LOG mmio.INDEX_X)
-    (* mmio.EXO_IS_LOG mmio.LIMB)
-    (* mmio.EXO_IS_LOG mmio.SIZE)
-    (* mmio.EXO_IS_LOG mmio.TOTAL_SIZE)
+    mmio.EXO_ID
+    mmio.INDEX_X
+    mmio.LIMB
+    mmio.SIZE
+    mmio.TOTAL_SIZE
   ))
 
 

--- a/mmio/lookups/mmio_into_ripsha.lisp
+++ b/mmio/lookups/mmio_into_ripsha.lisp
@@ -1,6 +1,6 @@
-(deflookup
+(defclookup
   mmio-into-ripsha
-  ;reference columns
+  ;; target columns
   (
     shakiradata.ID
     shakiradata.PHASE
@@ -9,12 +9,14 @@
     shakiradata.nBYTES
     shakiradata.TOTAL_SIZE
   )
-  ;source columns
+  ;; source selector
+  mmio.EXO_IS_RIPSHA
+  ;; source columns
   (
-    (* mmio.EXO_IS_RIPSHA mmio.EXO_ID)
-    (* mmio.EXO_IS_RIPSHA mmio.PHASE)
-    (* mmio.EXO_IS_RIPSHA mmio.INDEX_X)
-    (* mmio.EXO_IS_RIPSHA mmio.LIMB)
-    (* mmio.EXO_IS_RIPSHA mmio.SIZE)
-    (* mmio.EXO_IS_RIPSHA mmio.TOTAL_SIZE)
+    mmio.EXO_ID
+    mmio.PHASE
+    mmio.INDEX_X
+    mmio.LIMB
+    mmio.SIZE
+    mmio.TOTAL_SIZE
   ))

--- a/mmio/lookups/mmio_into_rom.lisp
+++ b/mmio/lookups/mmio_into_rom.lisp
@@ -1,18 +1,20 @@
-(deflookup
+(defclookup
   mmio-into-rom
-  ;reference columns
+  ;; target columns
   (
     rom.CFI
     rom.INDEX
     rom.LIMB
     rom.CODE_SIZE
   )
-  ;source columns
+  ;; source selector
+  mmio.EXO_IS_ROM
+  ;; source columns
   (
-    (* mmio.EXO_IS_ROM mmio.EXO_ID)
-    (* mmio.EXO_IS_ROM mmio.INDEX_X)
-    (* mmio.EXO_IS_ROM mmio.LIMB)
-    (* mmio.EXO_IS_ROM mmio.TOTAL_SIZE)
+    mmio.EXO_ID
+    mmio.INDEX_X
+    mmio.LIMB
+    mmio.TOTAL_SIZE
   ))
 
 

--- a/mmu/lookups/mmu_into_euc.lisp
+++ b/mmu/lookups/mmu_into_euc.lisp
@@ -1,9 +1,9 @@
 (defun (mmu-to-euc-selector)
   (* mmu.PRPRC mmu.prprc/EUC_FLAG))
 
-(deflookup
+(defclookup
   mmu-into-euc
-  ;reference columns
+  ;;target columns
   (
     euc.DIVIDEND
     euc.DIVISOR
@@ -12,14 +12,16 @@
     euc.CEIL
     euc.DONE
   )
-  ;source columns
+  ;; source selector
+  (mmu-to-euc-selector)
+  ;; source columns
   (
-    (* mmu.prprc/EUC_A (mmu-to-euc-selector))
-    (* mmu.prprc/EUC_B (mmu-to-euc-selector))
-    (* mmu.prprc/EUC_QUOT (mmu-to-euc-selector))
-    (* mmu.prprc/EUC_REM (mmu-to-euc-selector))
-    (* mmu.prprc/EUC_CEIL (mmu-to-euc-selector))
-    (mmu-to-euc-selector)
+    mmu.prprc/EUC_A
+    mmu.prprc/EUC_B
+    mmu.prprc/EUC_QUOT
+    mmu.prprc/EUC_REM
+    mmu.prprc/EUC_CEIL
+    1
   ))
 
 

--- a/mmu/lookups/mmu_into_wcp.lisp
+++ b/mmu/lookups/mmu_into_wcp.lisp
@@ -1,9 +1,9 @@
 (defun (mmu-to-wcp-selector)
   (* mmu.PRPRC mmu.prprc/WCP_FLAG))
 
-(deflookup
+(defclookup
   mmu-into-wcp
-  ;reference columns
+  ;; target columns
   (
     wcp.ARG_1_HI
     wcp.ARG_1_LO
@@ -12,14 +12,16 @@
     wcp.RES
     wcp.INST
   )
-  ;source columns
+  ;; source selector
+  (mmu-to-wcp-selector)
+  ;; source columns
   (
-    (* mmu.prprc/WCP_ARG_1_HI (mmu-to-wcp-selector))
-    (* mmu.prprc/WCP_ARG_1_LO (mmu-to-wcp-selector))
+    mmu.prprc/WCP_ARG_1_HI
+    mmu.prprc/WCP_ARG_1_LO
     0
-    (* mmu.prprc/WCP_ARG_2_LO (mmu-to-wcp-selector))
-    (* mmu.prprc/WCP_RES (mmu-to-wcp-selector))
-    (* mmu.prprc/WCP_INST (mmu-to-wcp-selector))
+    mmu.prprc/WCP_ARG_2_LO
+    mmu.prprc/WCP_RES
+    mmu.prprc/WCP_INST
   ))
 
 

--- a/oob/london/lookups/oob-into-add.lisp
+++ b/oob/london/lookups/oob-into-add.lisp
@@ -1,9 +1,9 @@
-(defun (mxp-into-add-activation-flag)
+(defun (oob-into-add-activation-flag)
   oob.ADD_FLAG)
 
-(deflookup
+(defclookup
   oob-into-add
-  ;source columns
+  ;; target columns
   (
     add.ARG_1_HI
     add.ARG_1_LO
@@ -13,15 +13,17 @@
     add.RES_LO
     add.INST
   )
-  ;target columns
+  ;; source selector
+  (oob-into-add-activation-flag)
+  ;; source columns
   (
-    (* [oob.OUTGOING_DATA 1] (mxp-into-add-activation-flag))
-    (* [oob.OUTGOING_DATA 2] (mxp-into-add-activation-flag))
-    (* [oob.OUTGOING_DATA 3] (mxp-into-add-activation-flag))
-    (* [oob.OUTGOING_DATA 4] (mxp-into-add-activation-flag))
-    (* (next [oob.OUTGOING_DATA 1]) (mxp-into-add-activation-flag))
-    (* (next [oob.OUTGOING_DATA 2]) (mxp-into-add-activation-flag))
-    (* oob.OUTGOING_INST (mxp-into-add-activation-flag))
+    [oob.OUTGOING_DATA 1]
+    [oob.OUTGOING_DATA 2]
+    [oob.OUTGOING_DATA 3]
+    [oob.OUTGOING_DATA 4]
+    (next [oob.OUTGOING_DATA 1])
+    (next [oob.OUTGOING_DATA 2])
+    oob.OUTGOING_INST
   ))
 
 

--- a/oob/london/lookups/oob-into-mod.lisp
+++ b/oob/london/lookups/oob-into-mod.lisp
@@ -1,9 +1,9 @@
 (defun (oob-into-mod-activation-flag)
   oob.MOD_FLAG)
 
-(deflookup
+(defclookup
   oob-into-mod
-  ;source columns
+  ;; target columns
   (
     mod.ARG_1_HI
     mod.ARG_1_LO
@@ -12,16 +12,18 @@
     mod.RES_HI
     mod.RES_LO
     mod.INST
-  )
-  ;target columns
+    )
+  ;; source selector
+  (oob-into-mod-activation-flag)
+  ;; source columns
   (
-    (* [oob.OUTGOING_DATA 1] (oob-into-mod-activation-flag))
-    (* [oob.OUTGOING_DATA 2] (oob-into-mod-activation-flag))
-    (* [oob.OUTGOING_DATA 3] (oob-into-mod-activation-flag))
-    (* [oob.OUTGOING_DATA 4] (oob-into-mod-activation-flag))
-    (* 0 (oob-into-mod-activation-flag))
-    (* oob.OUTGOING_RES_LO (oob-into-mod-activation-flag))
-    (* oob.OUTGOING_INST (oob-into-mod-activation-flag))
+    [oob.OUTGOING_DATA 1]
+    [oob.OUTGOING_DATA 2]
+    [oob.OUTGOING_DATA 3]
+    [oob.OUTGOING_DATA 4]
+    0
+    oob.OUTGOING_RES_LO
+    oob.OUTGOING_INST
   ))
 
 

--- a/oob/london/lookups/oob-into-wcp.lisp
+++ b/oob/london/lookups/oob-into-wcp.lisp
@@ -1,8 +1,9 @@
 (defun (oob-into-wcp-activation-flag)
   oob.WCP_FLAG)
 
-(deflookup
+(defclookup
   oob-into-wcp
+  ;; target columns
   (
     wcp.ARGUMENT_1_HI
     wcp.ARGUMENT_1_LO
@@ -11,13 +12,16 @@
     wcp.RESULT
     wcp.INST
   )
+  ;; source selector
+  (oob-into-wcp-activation-flag)
+  ;; source columns
   (
-    (* [oob.OUTGOING_DATA 1] (oob-into-wcp-activation-flag))
-    (* [oob.OUTGOING_DATA 2] (oob-into-wcp-activation-flag))
-    (* [oob.OUTGOING_DATA 3] (oob-into-wcp-activation-flag))
-    (* [oob.OUTGOING_DATA 4] (oob-into-wcp-activation-flag))
-    (* oob.OUTGOING_RES_LO (oob-into-wcp-activation-flag))
-    (* oob.OUTGOING_INST (oob-into-wcp-activation-flag))
+    [oob.OUTGOING_DATA 1]
+    [oob.OUTGOING_DATA 2]
+    [oob.OUTGOING_DATA 3]
+    [oob.OUTGOING_DATA 4]
+    oob.OUTGOING_RES_LO
+    oob.OUTGOING_INST
   ))
 
 

--- a/rlptxn/lookups/rlp_txn_into_hub.lisp
+++ b/rlptxn/lookups/rlp_txn_into_hub.lisp
@@ -1,6 +1,6 @@
 (defun (rlp-txn-into-hub-src-selector) (* rlptxn.REQUIRES_EVM_EXECUTION rlptxn.IS_PHASE_ACCESS_LIST (- 1 rlptxn.IS_PREFIX)))
 
-(deflookup 
+(defclookup 
   rlptxn-into-hub
   ;; target columns
   (
@@ -13,16 +13,18 @@
    (prewarming-phase-storage-key-hi)
    (prewarming-phase-storage-key-lo)
    )
+  ;; source selector
+  (rlp-txn-into-hub-src-selector)
   ;; source columns
   (
-                                            (rlp-txn-into-hub-src-selector)
-   (* rlptxn.ABS_TX_NUM                     (rlp-txn-into-hub-src-selector))
-   (* (- 1 (rlp-txn-depth-2))               (rlp-txn-into-hub-src-selector))
-   (* (rlp-txn-depth-2)                     (rlp-txn-into-hub-src-selector))
-   (* rlptxn.ADDR_HI                        (rlp-txn-into-hub-src-selector))
-   (* rlptxn.ADDR_LO                        (rlp-txn-into-hub-src-selector))
-   (* [rlptxn.INPUT 1] (rlp-txn-depth-2)    (rlp-txn-into-hub-src-selector))
-   (* [rlptxn.INPUT 2] (rlp-txn-depth-2)    (rlp-txn-into-hub-src-selector))
+   1
+   rlptxn.ABS_TX_NUM
+   (- 1 (rlp-txn-depth-2))
+   (rlp-txn-depth-2)
+   rlptxn.ADDR_HI
+   rlptxn.ADDR_LO
+   (* [rlptxn.INPUT 1] (rlp-txn-depth-2))
+   (* [rlptxn.INPUT 2] (rlp-txn-depth-2))
    )
   )
 

--- a/rlptxn/lookups/rlptxn_into_rom.lisp
+++ b/rlptxn/lookups/rlptxn_into_rom.lisp
@@ -2,7 +2,7 @@
 (defun (sel-rlptxn-to-rom)
   (* (~ rlptxn.CODE_FRAGMENT_INDEX) rlptxn.IS_PHASE_DATA (- 1 rlptxn.IS_PREFIX) rlptxn.LC))
 
-(deflookup
+(defclookup
   rlptxn-into-rom
   ;; target columns
   (
@@ -11,12 +11,14 @@
     rom.INDEX
     rom.nBYTES
   )
+  ;; source selector
+  (sel-rlptxn-to-rom)
   ;; source columns
   (
-    (* rlptxn.CODE_FRAGMENT_INDEX (sel-rlptxn-to-rom))
-    (* rlptxn.LIMB (sel-rlptxn-to-rom))
-    (* rlptxn.INDEX_DATA (sel-rlptxn-to-rom))
-    (* rlptxn.nBYTES (sel-rlptxn-to-rom))
+    rlptxn.CODE_FRAGMENT_INDEX
+    rlptxn.LIMB
+    rlptxn.INDEX_DATA
+    rlptxn.nBYTES
   ))
 
 

--- a/shakiradata/lookups/shakira_into_wcp_increasing_id.lisp
+++ b/shakiradata/lookups/shakira_into_wcp_increasing_id.lisp
@@ -11,7 +11,7 @@
   (force-bin (* (is-data)
                 (- 1 (prev (is-data))))))
 
-(deflookup
+(defclookup
   shakiradata-into-wcp-increasing-id
   ; target colums (in WCP)
   (
@@ -22,12 +22,14 @@
     wcp.RES
     wcp.INST
   )
+  ; source selector
+  (is-first-data-row)
   ; source columns
   (
     0
-    (* (is-first-data-row) (prev shakiradata.ID))
+    (prev shakiradata.ID)
     0
-    (* (is-first-data-row) shakiradata.ID)
-    (* (is-first-data-row) 1)
-    (* (is-first-data-row) EVM_INST_LT)
+    shakiradata.ID
+    1
+    EVM_INST_LT
   ))

--- a/shakiradata/lookups/shakira_into_wcp_nonzero_last_nbytes.lisp
+++ b/shakiradata/lookups/shakira_into_wcp_nonzero_last_nbytes.lisp
@@ -9,7 +9,7 @@
 (defun (is-final-data-row)
   (force-bin (* (is-data) (next (is-result)))))
 
-(deflookup
+(defclookup
   shakiradata-into-wcp-nonzero-last-nbytes
   ; target colums (in WCP)
   (
@@ -20,14 +20,16 @@
     wcp.RES
     wcp.INST
   )
+  ; source selector
+  (is-final-data-row)
   ; source columns
   (
     0
-    (* (is-final-data-row) shakiradata.nBYTES)
+    shakiradata.nBYTES
     0
     0
-    (* (is-final-data-row) 1)
-    (* (is-final-data-row) EVM_INST_GT)
+    1
+    EVM_INST_GT
   ))
 
 

--- a/shakiradata/lookups/shakira_into_wcp_small_last_nbytes.lisp
+++ b/shakiradata/lookups/shakira_into_wcp_small_last_nbytes.lisp
@@ -1,4 +1,4 @@
-(deflookup
+(defclookup
   shakiradata-into-wcp-small-last-nbytes
   ; target colums (in WCP)
   (
@@ -9,14 +9,16 @@
     wcp.RES
     wcp.INST
   )
+  ; source selector
+  (is-final-data-row)
   ; source columns
   (
     0
-    (* (is-final-data-row) shakiradata.nBYTES)
+    shakiradata.nBYTES
     0
-    (* (is-final-data-row) LLARGE)
-    (* (is-final-data-row) 1)
-    (* (is-final-data-row) WCP_INST_LEQ)
+    LLARGE
+    1
+    WCP_INST_LEQ
   ))
 
 

--- a/stp/lookups/stp_into_mod.lisp
+++ b/stp/lookups/stp_into_mod.lisp
@@ -1,4 +1,4 @@
-(deflookup
+(defclookup
   stp-into-mod
   ; target columns (in MOD)
   (
@@ -10,15 +10,17 @@
     mod.RES_LO
     mod.INST
   )
+  ; source selector
+  stp.MOD_FLAG
   ; source columns (in STP)
   (
-    (* stp.ARG_1_HI stp.MOD_FLAG)
-    (* stp.ARG_1_LO stp.MOD_FLAG)
+    stp.ARG_1_HI
+    stp.ARG_1_LO
     0
-    (* stp.ARG_2_LO stp.MOD_FLAG)
+    stp.ARG_2_LO
     0
-    (* stp.RES_LO stp.MOD_FLAG)
-    (* stp.EXO_INST stp.MOD_FLAG)
+    stp.RES_LO
+    stp.EXO_INST
   ))
 
 

--- a/stp/lookups/stp_into_wcp.lisp
+++ b/stp/lookups/stp_into_wcp.lisp
@@ -1,4 +1,4 @@
-(deflookup
+(defclookup
   stp-into-wcp
   ; target colums (in WCP)
   (
@@ -9,14 +9,16 @@
     wcp.RES
     wcp.INST
   )
+  ; source selector
+  stp.WCP_FLAG
   ; source columns (in STP)
   (
-    (* stp.ARG_1_HI stp.WCP_FLAG)
-    (* stp.ARG_1_LO stp.WCP_FLAG)
+    stp.ARG_1_HI
+    stp.ARG_1_LO
     0
-    (* stp.ARG_2_LO stp.WCP_FLAG)
-    (* stp.RES_LO stp.WCP_FLAG)
-    (* stp.EXO_INST stp.WCP_FLAG)
+    stp.ARG_2_LO
+    stp.RES_LO
+    stp.EXO_INST
   ))
 
 

--- a/txndata/london/lookups/txndata_into_euc.lisp
+++ b/txndata/london/lookups/txndata_into_euc.lisp
@@ -1,4 +1,4 @@
-(deflookup
+(defclookup
   txndata-into-euc
   ; target columns
   (
@@ -6,13 +6,15 @@
     euc.DIVIDEND
     euc.DIVISOR
     euc.QUOTIENT
-  )
+    )
+  ; source selector
+  txndata.EUC_FLAG
   ; source columns
   (
-    txndata.EUC_FLAG
-    (* txndata.EUC_FLAG txndata.ARG_ONE_LO)
-    (* txndata.EUC_FLAG txndata.ARG_TWO_LO)
-    (* txndata.EUC_FLAG txndata.RES)
+    1
+    txndata.ARG_ONE_LO
+    txndata.ARG_TWO_LO
+    txndata.RES
   ))
 
 

--- a/txndata/london/lookups/txndata_into_rlpaddr.lisp
+++ b/txndata/london/lookups/txndata_into_rlpaddr.lisp
@@ -1,7 +1,7 @@
 (defun (sel-txndata-to-rlpaddr)
   txndata.IS_DEP)
 
-(deflookup
+(defclookup
   txndata-into-rlpaddr
   ;; target columns
   (
@@ -12,14 +12,16 @@
     rlpaddr.NONCE
     rlpaddr.RECIPE_1
   )
+  ;; source selector
+  (sel-txndata-to-rlpaddr)
   ;; source columns
   (
-    (* txndata.FROM_HI (sel-txndata-to-rlpaddr))
-    (* txndata.FROM_LO (sel-txndata-to-rlpaddr))
-    (* txndata.TO_HI (sel-txndata-to-rlpaddr))
-    (* txndata.TO_LO (sel-txndata-to-rlpaddr))
-    (* txndata.NONCE (sel-txndata-to-rlpaddr))
-    (* txndata.IS_DEP (sel-txndata-to-rlpaddr))
+    txndata.FROM_HI
+    txndata.FROM_LO
+    txndata.TO_HI
+    txndata.TO_LO
+    txndata.NONCE
+    txndata.IS_DEP
   ))
 
 

--- a/txndata/london/lookups/txndata_into_rlptxrcpt.lisp
+++ b/txndata/london/lookups/txndata_into_rlptxrcpt.lisp
@@ -1,4 +1,4 @@
-(deflookup
+(defclookup
   txndata-into-rlptxrcpt
   ;; target columns
   (
@@ -6,13 +6,15 @@
     rlptxrcpt.ABS_TX_NUM
     rlptxrcpt.PHASE_ID
     [rlptxrcpt.INPUT 1]
-  )
+    )
+  ;; source selector
+  (~ txndata.PHASE_RLP_TXNRCPT)  
   ;; source columns
   (
-    (* txndata.ABS_TX_NUM_MAX (~ txndata.PHASE_RLP_TXNRCPT))
-    (* txndata.ABS_TX_NUM (~ txndata.PHASE_RLP_TXNRCPT))
-    (* txndata.PHASE_RLP_TXNRCPT (~ txndata.PHASE_RLP_TXNRCPT))
-    (* txndata.OUTGOING_RLP_TXNRCPT (~ txndata.PHASE_RLP_TXNRCPT))
+    txndata.ABS_TX_NUM_MAX
+    txndata.ABS_TX_NUM
+    txndata.PHASE_RLP_TXNRCPT
+    txndata.OUTGOING_RLP_TXNRCPT
   ))
 
 

--- a/txndata/london/lookups/txndata_into_romlex.lisp
+++ b/txndata/london/lookups/txndata_into_romlex.lisp
@@ -1,7 +1,7 @@
 (defun (sel-txn-data-to-rom-lex)
   (* txndata.IS_DEP (~ txndata.INIT_CODE_SIZE)))
 
-(deflookup
+(defclookup
   txndata-into-romlex
   ;; target columns
   (
@@ -12,14 +12,16 @@
     romlex.DEPLOYMENT_NUMBER
     romlex.DEPLOYMENT_STATUS
   )
+  ;; source selector
+  (sel-txn-data-to-rom-lex)
   ;; source columns
   (
-    (* txndata.CODE_FRAGMENT_INDEX (sel-txn-data-to-rom-lex))
-    (* txndata.INIT_CODE_SIZE (sel-txn-data-to-rom-lex))
-    (* txndata.TO_HI (sel-txn-data-to-rom-lex))
-    (* txndata.TO_LO (sel-txn-data-to-rom-lex))
-    (sel-txn-data-to-rom-lex)
-    (sel-txn-data-to-rom-lex)
+    txndata.CODE_FRAGMENT_INDEX
+    txndata.INIT_CODE_SIZE
+    txndata.TO_HI
+    txndata.TO_LO
+    1
+    1
   ))
 
 

--- a/txndata/london/lookups/txndata_into_wcp.lisp
+++ b/txndata/london/lookups/txndata_into_wcp.lisp
@@ -1,4 +1,4 @@
-(deflookup
+(defclookup
   txndata-into-wcp
   ; target columns
   (
@@ -8,15 +8,17 @@
     wcp.ARGUMENT_2_LO
     wcp.RESULT
     wcp.INST
-  )
+    )
+  ; source selector
+  txndata.WCP_FLAG
   ; source columns
   (
     0
-    (* txndata.WCP_FLAG txndata.ARG_ONE_LO)
+    txndata.ARG_ONE_LO
     0
-    (* txndata.WCP_FLAG txndata.ARG_TWO_LO)
-    (* txndata.WCP_FLAG txndata.RES)
-    (* txndata.WCP_FLAG txndata.INST)
+    txndata.ARG_TWO_LO
+    txndata.RES
+    txndata.INST
   ))
 
 


### PR DESCRIPTION
This replaces lookups with conditional lookups where it makes sense to do so in the LONDON fork.  Conditional lookups offer performance benefits, as they do not generated computed columns to implement selectors.

**NOTE:** do not merge yet!