### PR TITLE
fix: Add quotes around wildcard pattern in find command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ TXN_DATA_CANCUN := txndata/cancun
 
 WCP := wcp
 
-LISPX := $(shell find * -name *.lispX)
+LISPX := $(shell find * -name "*.lispX")
 # Warn about any lispX files
 define warn_lispX
 	@for FILE in ${LISPX}; do (echo "WARNING: $$FILE"); done


### PR DESCRIPTION
Fixes a potential shell globbing issue in the Makefile by adding quotes around the wildcard pattern in the find command. Without quotes, the shell might expand the pattern before the find command is executed, leading to unexpected behavior if there are matching files in the current directory. This is a standard best practice for shell commands in Makefiles