### PR TITLE
fix: compilation failures around lookups

### DIFF
--- a/bin/lookups/bin_into_binreftable.lisp
+++ b/bin/lookups/bin_into_binreftable.lisp
@@ -1,5 +1,5 @@
 (defun (selector-bin-to-binreftable)
-  (+ bin.IS_AND bin.IS_OR bin.IS_XOR bin.IS_NOT))
+  (force-bin (+ bin.IS_AND bin.IS_OR bin.IS_XOR bin.IS_NOT)))
 
 (defclookup
   bin-into-binreftable-high

--- a/hub/shanghai/lookups/hub_into_wcp_for_stack_overflow.lisp
+++ b/hub/shanghai/lookups/hub_into_wcp_for_stack_overflow.lisp
@@ -1,7 +1,7 @@
 (defun (hub-into-wcp-for-sox-activation-flag)
   (* hub.PEEK_AT_STACK (- 1 hub.stack/SUX)))
 
-(defun (projected-height)
+(defun ((projected-height :i16 :force))
   (* (- (+ hub.HEIGHT hub.stack/ALPHA) hub.stack/DELTA)
      (- 1 hub.stack/SUX)))
 


### PR DESCRIPTION
This fixes a small number of compilation failures which arise with the latest version of go-corset.fix compilation failures around lookups