### PR TITLE
fix: add guard and switch property to constraint for access list rlp …

### DIFF
--- a/rlptxn/cancun/constraints/phase/access_list/sub_phases/RLP-ization_of_prefix_of_the_full_access_list.lisp
+++ b/rlptxn/cancun/constraints/phase/access_list/sub_phases/RLP-ization_of_prefix_of_the_full_access_list.lisp
@@ -16,8 +16,9 @@
 (defun (access-list-is-non-empty)        cmp/EXO_DATA_4) ;; ""
 (defun (access-list-is-empty)            (- 1 (access-list-is-non-empty)))
 
-(defproperty    access-list---rlp-prefix-of-the-full-access-list---sanity-checks
-                (if-zero   PHASE_END
+(defconstraint    access-list---rlp-prefix-of-the-full-access-list---sanity-checks
+                 (:guard   (is-access-list-prefix))
+                 (if-zero  PHASE_END
                            (begin
                              (eq!   IS_PREFIX_OF_ACCESS_LIST_ITEM   1)
                              (eq!   IS_ACCESS_LIST_ADDRESS          0)


### PR DESCRIPTION
…prefix sanity check

As there is a guard, I had to switch from  `defproperty` to `defconstraint` 