### PR TITLE
fix: increase stamp size for blake2f to fix ref tests

### DIFF
--- a/blake2fmodexpdata/columns.lisp
+++ b/blake2fmodexpdata/columns.lisp
@@ -1,7 +1,7 @@
 (module blake2fmodexpdata)
 
 (defcolumns
-  (STAMP                :i10)
+  (STAMP                :i16)
   (ID                   :i32)
   (PHASE                :byte)
   (INDEX                :byte :display :dec)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase `STAMP` column type from `:i10` to `:i16` in `blake2fmodexpdata/columns.lisp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 507f8fe7254b0750d6345a40c5fd31190eaa4e16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->