### PR TITLE
feat: update go-corset to version 1.1.23

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@5b76fc01d8ea4e8f78e5e1991665cb2036c8ea6e # v1.1.22
+      run: go install github.com/consensys/go-corset/cmd/go-corset@93c23f239542f79c1db60eb5b8250ab20e30f046 # v1.1.23
 
     - name: Build all forks
       run: make -B all

--- a/alu/add/add.zkasm
+++ b/alu/add/add.zkasm
@@ -8,7 +8,7 @@ include "../../constants/evm.zkasm"
 ;; SUB    (ARG_1 - ARG_2) % 2^256                   0x03
 ;;
 ;; Both of these operate on u256 words with "wrap around" semantics.
-fn add(INST=1 u8, ARG_1 u256, ARG_2 u256) -> (RES u256) {
+pub fn add(INST=1 u8, ARG_1 u256, ARG_2 u256) -> (RES u256) {
   var c u1
   ;;
   if INST == EVM_INST_ADD goto insn_add

--- a/exp/exp.zkasm
+++ b/exp/exp.zkasm
@@ -20,7 +20,7 @@ const EXP_INST_MODEXPLOG = 0xEE05
 ;; The interpretation of the argument ARG depends upon the
 ;; instruction, whilst CDS and EBS are only used for the MODEXPLOG
 ;; case.
-fn exp(INST=0xEE0A u16, ARG u256, CDS u6, EBS u6) -> (RES=0 u128)
+pub fn exp(INST=0xEE0A u16, ARG u256, CDS u6, EBS u6) -> (RES=0 u128)
 ;; PRE: 1<=CDS<=32 && 1<=EBS<=32
 {
    var s, b u1

--- a/gas/gas.zkasm
+++ b/gas/gas.zkasm
@@ -4,7 +4,7 @@
 ;; "Out Of Gas Exception".  When OOGX==1, it means the corresponding
 ;; instruction generated an out-of-gas exception (rather than some
 ;; other exception kind).
-fn gas(GAS_COST u64, GAS_ACTUAL u64, XAHOY u1, OOGX u1) {
+pub fn gas(GAS_COST u64, GAS_ACTUAL u64, XAHOY u1, OOGX u1) {
   var tmp u64
   var b u1
   ;;

--- a/shf/shf.zkasm
+++ b/shf/shf.zkasm
@@ -14,7 +14,7 @@ include "../util/bit_sar.zkasm"
 ;; Observe that when ARG_1 >= 256, the result is always 0 for SHL and
 ;; SHR.  For SAR, the result in this case is 0 (when sign bit unset)
 ;; and -1 (when sign bit set).
-fn shf(INST=0x1b u8, ARG_1 u256, ARG_2 u256) -> (RES u256) {
+pub fn shf(INST=0x1b u8, ARG_1 u256, ARG_2 u256) -> (RES u256) {
   var tmp u248
   var n u8
   ;; split shift

--- a/stp/stp.zkasm
+++ b/stp/stp.zkasm
@@ -22,7 +22,7 @@ include "../constants/evm.zkasm"
 ;; Finally, EXISTS indicates for a CALL instruction whether target
 ;; account exists already, and WARM indicates whether the target
 ;; account for a call instruction is warm (or not).
-fn stp(INST=0xf0 u8, GAS_ACTUAL u64, GAS_MXP u64, GAS u256, VALUE u256, EXISTS u1, WARM u1) -> (OOGX=1 u1, GAS_UPFRONT=32000 u64, GAS_OOP u64, GAS_STIPEND u64)
+pub fn stp(INST=0xf0 u8, GAS_ACTUAL u64, GAS_MXP u64, GAS u256, VALUE u256, EXISTS u1, WARM u1) -> (OOGX=1 u1, GAS_UPFRONT=32000 u64, GAS_OOP u64, GAS_STIPEND u64)
 ;; PRE: GAS_UPFRONT calculation does not overflow.
 {
   var L_gas_diff u64


### PR DESCRIPTION
This adds a requirement that we mark externally visible functions with the "pub" modifier.  Thus, this PR also does that for those which need to be visible in the inspector, and also in the Tracer.java interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates go-corset to v1.1.23 and marks key zkASM functions as public (`add`, `exp`, `gas`, `shf`, `stp`).
> 
> - **CI**:
>   - Update `go-corset` in `.github/workflows/check.yml` to `v1.1.23`.
> - **zkASM**: export functions with `pub`:
>   - `alu/add/add.zkasm`: `add`
>   - `exp/exp.zkasm`: `exp`
>   - `gas/gas.zkasm`: `gas`
>   - `shf/shf.zkasm`: `shf`
>   - `stp/stp.zkasm`: `stp`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 335ff9099149a4946b74b9c224bb67c4ffdf4717. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->