### PR TITLE
feat: update `call_gas_extra()` in `stp`

### DIFF
--- a/constants/evm.zkasm
+++ b/constants/evm.zkasm
@@ -8,6 +8,8 @@ const EVM_INST_SHL                              = 0x1b
 const EVM_INST_SHR                              = 0x1c
 const EVM_INST_SAR                              = 0x1d
 const EVM_INST_CREATE                           = 0xF0
+const EVM_INST_CALL                             = 0xF1
+const EVM_INST_CALLCODE                         = 0xF2
 const EVM_INST_CREATE2                          = 0xF5
 
 ;; =============================================================================

--- a/stp/stp.zkasm
+++ b/stp/stp.zkasm
@@ -74,41 +74,30 @@ failed_pre:
 fn call_gas_extra(inst=0xf1 u8, value u256, warm u1, exists u1) -> (gas_extra=2600 u64, stipend u64)
 ;; PRE: inst in {0xf1,0xf2,0xf4,0xf5]
 {
-  var gas_transfer u16
-  var gas_new_account u16
   var gas_access u16
+  var notWarm, notExists u1
+  ;; inversions
+  notWarm = 1 - warm
+  notExists = 1 - exists
+  ;; calculate gas access cost
+  gas_access = (warm * G_WARMACCESS) + (notWarm * G_COLDACCOUNTACCESS)
   ;;
-  if inst == 0xf1 goto call_only
-  if inst == 0xf2 goto call_other
-  if inst == 0xf4 goto call_no_transfer
-  if inst == 0xfa goto call_no_transfer
-  fail
-call_only:
   if value == 0 goto call_no_transfer
-  if exists == 1 goto call_other
-  stipend = G_CALLSTIPEND
-  gas_transfer = G_CALLVALUE
-  gas_new_account = G_NEWACCOUNT
-  goto call
-call_other:
-  if value == 0 goto call_no_transfer
-  stipend = G_CALLSTIPEND
-  gas_transfer = G_CALLVALUE
-  gas_new_account = 0
-  goto call
-call_no_transfer:
-  stipend = 0
-  gas_transfer = 0
-  gas_new_account = 0
+  if inst == EVM_INST_CALL goto call
+  if inst == EVM_INST_CALLCODE goto callcode
+  goto call_no_transfer
 call:
-  ;; check for warm access
-  if warm == 0 goto call_cold
-  gas_access = G_WARMACCESS
-  goto call_cont
-call_cold:
-  gas_access = G_COLDACCOUNTACCESS
-call_cont:
-  gas_extra = gas_access + gas_transfer + gas_new_account
+  stipend = G_CALLSTIPEND
+  gas_extra = gas_access + G_CALLVALUE + (notExists * G_NEWACCOUNT)
+  return
+callcode:
+  stipend = G_CALLSTIPEND
+  gas_extra = gas_access + G_CALLVALUE
+  return
+call_no_transfer:
+  ;; staticcall / delegatecall
+  stipend=0
+  gas_extra = gas_access
   return
 }
 


### PR DESCRIPTION
This updates the `call_gas_extra()` function within the `stp` module with a more efficient implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors call gas/stipend calculation to handle CALL vs CALLCODE with warm/cold access and new-account costs; adds EVM CALL and CALLCODE opcode constants.
> 
> - **STP**:
>   - **call_gas_extra()**: Refactors logic to compute `gas_access` via warm/cold access and derive `gas_extra` directly.
>     - Explicit branches for `EVM_INST_CALL` vs `EVM_INST_CALLCODE`; no-transfer path for static/delegate calls.
>     - Applies `G_CALLVALUE` and conditional `G_NEWACCOUNT` (only for non-existent accounts on `CALL`).
>     - Sets stipend to `G_CALLSTIPEND` only when transferring value; `0` otherwise.
> - **Constants**:
>   - Add `EVM_INST_CALL = 0xF1` and `EVM_INST_CALLCODE = 0xF2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9986b8286aff680d60c9e6f8d0a1b953a534223. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->