### PR TITLE
Update GitHub Actions to checkout@v5 and setup-go@v6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Install Go
-      uses: actions/setup-go@v5.1.0
+      uses: actions/setup-go@v6.0.0
 
     - name: Install Go Corset
       shell: bash


### PR DESCRIPTION
uses: actions/checkout@v3 -> uses: actions/checkout@v5

uses: actions/setup-go@v5.1.0 -> uses: actions/setup-go@v6.0.0

Reason:
These updates provide enhanced caching, better security, and compatibility with recent GitHub runner and Go releases.

Checkout v5 release notes: https://github.com/actions/checkout/releases/tag/v5.0.0
Setup-go v6 release notes: https://github.com/actions/setup-go/releases/tag/v6.0.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `.github/workflows/check.yml` to use `actions/checkout@v5` and `actions/setup-go@v6.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de34fb6898bbccb5809e6a3b653299aa6bf51ed5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->