### PR TITLE
Copy fixes to Osaka `OOB`

### DIFF
--- a/oob/osaka/columns.lisp
+++ b/oob/osaka/columns.lisp
@@ -42,7 +42,7 @@
   (ADD_FLAG :binary@prove)
   (MOD_FLAG :binary@prove)
   (BLS_REF_TABLE_FLAG :binary@prove)
-  (OUTGOING_INST :byte :display :opcode)
+  (OUTGOING_INST :i16 :display :opcode)
   (OUTGOING_DATA :i128 :array [4])
   (OUTGOING_RES_LO :i128))
 

--- a/oob/osaka/constants.lisp
+++ b/oob/osaka/constants.lisp
@@ -26,10 +26,10 @@
   CT_MAX_MODEXP_PRICING        5
   CT_MAX_MODEXP_EXTRACT        3
   CT_MAX_POINT_EVALUATION      3
-  CT_MAX_BLS_G1_ADD             3
-  CT_MAX_BLS_G1_MSM             6
-  CT_MAX_BLS_G2_ADD             3
-  CT_MAX_BLS_G2_MSM             6
+  CT_MAX_BLS_G1_ADD            3
+  CT_MAX_BLS_G1_MSM            7
+  CT_MAX_BLS_G2_ADD            3
+  CT_MAX_BLS_G2_MSM            7
   CT_MAX_BLS_PAIRING_CHECK     4
   CT_MAX_BLS_MAP_FP_TO_G1      3
   CT_MAX_BLS_MAP_FP2_TO_G2     3

--- a/oob/osaka/lookups/oob-into-add.lisp
+++ b/oob/osaka/lookups/oob-into-add.lisp
@@ -2,7 +2,7 @@
   oob.ADD_FLAG)
 
 (defclookup
-  oob-into-add
+  (oob-into-add :unchecked)
   ;; target columns
   (
     add.ARG_1

--- a/oob/osaka/lookups/oob-into-mod.lisp
+++ b/oob/osaka/lookups/oob-into-mod.lisp
@@ -2,7 +2,7 @@
   oob.MOD_FLAG)
 
 (defclookup
-  oob-into-mod
+  (oob-into-mod :unchecked)
   ;; target columns
   (
     mod.ARG_1_HI


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Widen `OUTGOING_INST` to `:i16`, increase `CT_MAX_BLS_G{1,2}_MSM` to 7, and set `oob-into-add`/`oob-into-mod` lookups to `:unchecked`.
> 
> - **Osaka OOB columns (`oob/osaka/columns.lisp`)**:
>   - Change `OUTGOING_INST` type from `:byte` to `:i16`.
> - **Constants (`oob/osaka/constants.lisp`)**:
>   - Increase `CT_MAX_BLS_G1_MSM` and `CT_MAX_BLS_G2_MSM` from `6` to `7`.
> - **Lookups**:
>   - `oob/osaka/lookups/oob-into-add.lisp`: mark `defclookup` as `:unchecked` for `oob-into-add`.
>   - `oob/osaka/lookups/oob-into-mod.lisp`: mark `defclookup` as `:unchecked` for `oob-into-mod`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c9fb4e06a81023ece4ad57fbc39a9cd614ddc6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->