### PR TITLE
fix: target selector for blockhash lookup

### DIFF
--- a/hub/cancun/columns/shared.lisp
+++ b/hub/cancun/columns/shared.lisp
@@ -8,8 +8,8 @@
     ( SYSF                                      :binary@prove )
 
     ;; block and transaction accounting
-    ( BLK_NUMBER                                :i24 )
-    ;; ( TOTL_TXN_NUMBER                           :i24 )
+    ( BLK_NUMBER                                :i16 )
+    ;; ( TOTL_TXN_NUMBER                           :i16 )
     ( SYSI_TXN_NUMBER                           :i24 )
     ( USER_TXN_NUMBER                           :i24 )
     ( SYSF_TXN_NUMBER                           :i24 )

--- a/hub/cancun/lookups/hub_into_block_hash.lisp
+++ b/hub/cancun/lookups/hub_into_block_hash.lisp
@@ -2,7 +2,9 @@
   (* hub.PEEK_AT_STACK (- 1 hub.XAHOY) hub.stack/BTC_FLAG [hub.stack/DEC_FLAG 1]))
 
 (defclookup
-  (hub-into-blockhash :unchecked)
+  hub-into-blockhash
+  ;; target selector
+  blockhash.MACRO
   ;; target columns
   (
     blockhash.macro/REL_BLOCK

--- a/hub/london/lookups/hub_into_block_hash.lisp
+++ b/hub/london/lookups/hub_into_block_hash.lisp
@@ -3,6 +3,8 @@
 
 (defclookup
   hub-into-blockhash
+  ;; target selector
+  blockhash.MACRO
   ;; target columns
   (
     blockhash.macro/REL_BLOCK

--- a/hub/osaka/columns/shared.lisp
+++ b/hub/osaka/columns/shared.lisp
@@ -8,8 +8,8 @@
     ( SYSF                                      :binary@prove )
 
     ;; block and transaction accounting
-    ( BLK_NUMBER                                :i24 )
-    ;; ( TOTL_TXN_NUMBER                           :i24 )
+    ( BLK_NUMBER                                :i16 )
+    ;; ( TOTL_TXN_NUMBER                           :i16 )
     ( SYSI_TXN_NUMBER                           :i24 )
     ( USER_TXN_NUMBER                           :i24 )
     ( SYSF_TXN_NUMBER                           :i24 )

--- a/hub/osaka/lookups/hub_into_block_hash.lisp
+++ b/hub/osaka/lookups/hub_into_block_hash.lisp
@@ -2,7 +2,9 @@
   (* hub.PEEK_AT_STACK (- 1 hub.XAHOY) hub.stack/BTC_FLAG [hub.stack/DEC_FLAG 1]))
 
 (defclookup
-  (hub-into-blockhash :unchecked)
+  hub-into-blockhash
+  ;; target selector
+  blockhash.MACRO
   ;; target columns
   (
     blockhash.macro/REL_BLOCK

--- a/hub/prague/columns/shared.lisp
+++ b/hub/prague/columns/shared.lisp
@@ -8,8 +8,8 @@
     ( SYSF                                      :binary@prove )
 
     ;; block and transaction accounting
-    ( BLK_NUMBER                                :i24 )
-    ;; ( TOTL_TXN_NUMBER                           :i24 )
+    ( BLK_NUMBER                                :i16 )
+    ;; ( TOTL_TXN_NUMBER                           :i16 )
     ( SYSI_TXN_NUMBER                           :i24 )
     ( USER_TXN_NUMBER                           :i24 )
     ( SYSF_TXN_NUMBER                           :i24 )

--- a/hub/prague/lookups/hub_into_block_hash.lisp
+++ b/hub/prague/lookups/hub_into_block_hash.lisp
@@ -2,7 +2,9 @@
   (* hub.PEEK_AT_STACK (- 1 hub.XAHOY) hub.stack/BTC_FLAG [hub.stack/DEC_FLAG 1]))
 
 (defclookup
-  (hub-into-blockhash :unchecked)
+  hub-into-blockhash
+  ;; target selector
+  blockhash.MACRO
   ;; target columns
   (
     blockhash.macro/REL_BLOCK

--- a/hub/shanghai/lookups/hub_into_block_hash.lisp
+++ b/hub/shanghai/lookups/hub_into_block_hash.lisp
@@ -3,6 +3,8 @@
 
 (defclookup
   hub-into-blockhash
+  ;; target selector
+  blockhash.MACRO
   ;; target columns
   (
     blockhash.macro/REL_BLOCK


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Specify blockhash.MACRO as the target selector for all hub-into-blockhash lookups and reduce BLK_NUMBER from i24 to i16 in hub columns.
> 
> - **Lookups**:
>   - **Target selector**: Set `blockhash.MACRO` for `hub-into-blockhash` in `hub/*/lookups/hub_into_block_hash.lisp` (cancun, london, osaka, prague, shanghai).
>   - Remove `:unchecked` from `defclookup` where present (cancun, osaka, prague).
> - **Columns**:
>   - Narrow `hub/*/columns/shared.lisp` `BLK_NUMBER` from `:i24` to `:i16` (cancun, osaka, prague).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca3c2a37976bd9b200d5ffa3930aa9804c722213. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->