### PR TITLE
Rename shorthand to `(precompile-processing---dup-callee-gas)` as in spec

### DIFF
--- a/hub/cancun/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
+++ b/hub/cancun/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
@@ -38,7 +38,7 @@
 (defconstraint    precompile-processing---BLAKE2f---setting-the-second-OOB-instruction
                   (:guard    (precompile-processing---BLAKE2f---surviving-the-HUB))
                   (set-OOB-instruction---blake-params    precompile-processing---BLAKE2f---misc-row-offset---BLAKE-call-data-extraction    ;; offset
-                                                         (precompile-processing---dup-call-gas)                                            ;; call gas i.e. gas provided to the precompile
+                                                         (precompile-processing---dup-callee-gas)                                          ;; call gas i.e. gas provided to the precompile
                                                          (precompile-processing---BLAKE2f---r-parameter)                                   ;; rounds parameter of the call data of BLAKE2f
                                                          (precompile-processing---BLAKE2f---f-parameter)                                   ;; f      parameter of the call data of BLAKE2f ("final block indicator")
                                                          ))

--- a/hub/cancun/constraints/instruction-handling/call/precompiles/common/generalities.lisp
+++ b/hub/cancun/constraints/instruction-handling/call/precompiles/common/generalities.lisp
@@ -33,7 +33,7 @@
 (defconstraint    precompile-processing---common---setting-OOB-instruction    (:guard    (precompile-processing---common---precondition))
                   (set-OOB-instruction---common    precompile-processing---common---1st-misc-row---row-offset  ;; offset
                                                    (precompile-processing---common---OOB-instruction)          ;; relevant OOB instruction
-                                                   (precompile-processing---dup-call-gas)                      ;; call gas i.e. gas provided to the precompile
+                                                   (precompile-processing---dup-callee-gas)                    ;; call gas i.e. gas provided to the precompile
                                                    (precompile-processing---dup-cds)                           ;; call data size
                                                    (precompile-processing---dup-r@c)                           ;; return at capacity
                                                    )

--- a/hub/cancun/constraints/instruction-handling/call/precompiles/modexp/common.lisp
+++ b/hub/cancun/constraints/instruction-handling/call/precompiles/modexp/common.lisp
@@ -256,7 +256,7 @@
 
 (defconstraint    precompile-processing---MODEXP---pricing-analysis---setting-OOB-instruction    (:guard    (precompile-processing---MODEXP---standard-precondition))
                   (set-OOB-instruction---modexp-pricing    precompile-processing---MODEXP---misc-row-offset---pricing   ;; offset
-                                                           (precompile-processing---dup-call-gas)                       ;; call gas i.e. gas provided to the precompile
+                                                           (precompile-processing---dup-callee-gas)                     ;; call gas i.e. gas provided to the precompile
                                                            (precompile-processing---dup-r@c)                            ;; return at capacity
                                                            (precompile-processing---MODEXP---modexp-full-log)           ;; leading (≤) word log of exponent
                                                            (precompile-processing---MODEXP---max-mbs-bbs)               ;; call data size

--- a/hub/cancun/constraints/instruction-handling/call/precompiles/shorthands.lisp
+++ b/hub/cancun/constraints/instruction-handling/call/precompiles/shorthands.lisp
@@ -20,7 +20,7 @@
 
 
 (defun    (precompile-processing---dup-caller-gas)    scenario/PRC_CALLER_GAS)
-(defun    (precompile-processing---dup-call-gas)      scenario/PRC_CALLEE_GAS)
+(defun    (precompile-processing---dup-callee-gas)    scenario/PRC_CALLEE_GAS)
 (defun    (precompile-processing---prd-return-gas)    scenario/PRC_RETURN_GAS)
 (defun    (precompile-processing---dup-cdo)           scenario/PRC_CDO)
 (defun    (precompile-processing---dup-cds)           scenario/PRC_CDS)

--- a/hub/london/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
+++ b/hub/london/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
@@ -37,7 +37,7 @@
 (defconstraint    precompile-processing---BLAKE2f---setting-the-second-OOB-instruction
                   (:guard    (precompile-processing---BLAKE2f---surviving-the-HUB))
                   (set-OOB-instruction---blake-params    precompile-processing---BLAKE2f---misc-row-offset---BLAKE-call-data-extraction    ;; offset
-                                                         (precompile-processing---dup-call-gas)                                            ;; call gas i.e. gas provided to the precompile
+                                                         (precompile-processing---dup-callee-gas)                                          ;; call gas i.e. gas provided to the precompile
                                                          (precompile-processing---BLAKE2f---r-parameter)                                   ;; rounds parameter of the call data of BLAKE2f
                                                          (precompile-processing---BLAKE2f---f-parameter)                                   ;; f      parameter of the call data of BLAKE2f ("final block indicator")
                                                          ))

--- a/hub/london/constraints/instruction-handling/call/precompiles/common/generalities.lisp
+++ b/hub/london/constraints/instruction-handling/call/precompiles/common/generalities.lisp
@@ -32,7 +32,7 @@
 (defconstraint    precompile-processing---common---setting-OOB-instruction    (:guard    (precompile-processing---common---precondition))
                   (set-OOB-instruction---common    precompile-processing---common---1st-misc-row---row-offset  ;; offset
                                                    (precompile-processing---common---OOB-instruction)          ;; relevant OOB instruction
-                                                   (precompile-processing---dup-call-gas)                      ;; call gas i.e. gas provided to the precompile
+                                                   (precompile-processing---dup-callee-gas)                    ;; call gas i.e. gas provided to the precompile
                                                    (precompile-processing---dup-cds)                           ;; call data size
                                                    (precompile-processing---dup-r@c)                           ;; return at capacity
                                                    )

--- a/hub/london/constraints/instruction-handling/call/precompiles/modexp/common.lisp
+++ b/hub/london/constraints/instruction-handling/call/precompiles/modexp/common.lisp
@@ -256,7 +256,7 @@
 
 (defconstraint    precompile-processing---MODEXP---pricing-analysis---setting-OOB-instruction    (:guard    (precompile-processing---MODEXP---standard-precondition))
                   (set-OOB-instruction---modexp-pricing    precompile-processing---MODEXP---misc-row-offset---pricing   ;; offset
-                                                           (precompile-processing---dup-call-gas)                       ;; call gas i.e. gas provided to the precompile
+                                                           (precompile-processing---dup-callee-gas)                     ;; call gas i.e. gas provided to the precompile
                                                            (precompile-processing---dup-r@c)                            ;; return at capacity
                                                            (precompile-processing---MODEXP---modexp-full-log)           ;; leading (≤) word log of exponent
                                                            (precompile-processing---MODEXP---max-mbs-bbs)               ;; call data size

--- a/hub/london/constraints/instruction-handling/call/precompiles/shorthands.lisp
+++ b/hub/london/constraints/instruction-handling/call/precompiles/shorthands.lisp
@@ -20,7 +20,7 @@
 
 
 (defun    (precompile-processing---dup-caller-gas)    scenario/PRC_CALLER_GAS)
-(defun    (precompile-processing---dup-call-gas)      scenario/PRC_CALLEE_GAS)
+(defun    (precompile-processing---dup-callee-gas)    scenario/PRC_CALLEE_GAS)
 (defun    (precompile-processing---prd-return-gas)    scenario/PRC_RETURN_GAS)
 (defun    (precompile-processing---dup-cdo)           scenario/PRC_CDO)
 (defun    (precompile-processing---dup-cds)           scenario/PRC_CDS)

--- a/hub/osaka/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
+++ b/hub/osaka/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
@@ -38,7 +38,7 @@
 (defconstraint    precompile-processing---BLAKE2f---setting-the-second-OOB-instruction
                   (:guard    (precompile-processing---BLAKE2f---surviving-the-HUB))
                   (set-OOB-instruction---blake-params    precompile-processing---BLAKE2f---misc-row-offset---BLAKE-call-data-extraction    ;; offset
-                                                         (precompile-processing---dup-call-gas)                                            ;; call gas i.e. gas provided to the precompile
+                                                         (precompile-processing---dup-callee-gas)                                          ;; call gas i.e. gas provided to the precompile
                                                          (precompile-processing---BLAKE2f---r-parameter)                                   ;; rounds parameter of the call data of BLAKE2f
                                                          (precompile-processing---BLAKE2f---f-parameter)                                   ;; f      parameter of the call data of BLAKE2f ("final block indicator")
                                                          ))

--- a/hub/osaka/constraints/instruction-handling/call/precompiles/common/generalities.lisp
+++ b/hub/osaka/constraints/instruction-handling/call/precompiles/common/generalities.lisp
@@ -35,7 +35,7 @@
                   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
                   (set-OOB-instruction---common    precompile-processing---common---1st-misc-row---row-offset  ;; offset
                                                    (precompile-processing---common---OOB-instruction)          ;; relevant OOB instruction
-                                                   (precompile-processing---dup-call-gas)                      ;; call gas i.e. gas provided to the precompile
+                                                   (precompile-processing---dup-callee-gas)                    ;; call gas i.e. gas provided to the precompile
                                                    (precompile-processing---dup-cds)                           ;; call data size
                                                    (precompile-processing---dup-r@c)                           ;; return at capacity
                                                    )

--- a/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__06__pricing_row.lisp
+++ b/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__06__pricing_row.lisp
@@ -41,7 +41,7 @@
                   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
                   (if-not-zero   (precompile-processing---MODEXP---call-OOB-on-pricing-row)
                                  (set-OOB-instruction---modexp-pricing    precompile-processing---MODEXP---misc-row-offset---pricing   ;; offset
-                                                                          (precompile-processing---dup-call-gas)                       ;; call gas i.e. gas provided to the precompile
+                                                                          (precompile-processing---dup-callee-gas)                     ;; call gas i.e. gas provided to the precompile
                                                                           (precompile-processing---dup-r@c)                            ;; return at capacity
                                                                           (precompile-processing---MODEXP---modexp-full-log)           ;; leading (≤) word log of exponent
                                                                           (precompile-processing---MODEXP---max-mbs-bbs)               ;; call data size

--- a/hub/osaka/constraints/instruction-handling/call/precompiles/shorthands.lisp
+++ b/hub/osaka/constraints/instruction-handling/call/precompiles/shorthands.lisp
@@ -20,7 +20,7 @@
 
 
 (defun    (precompile-processing---dup-caller-gas)    scenario/PRC_CALLER_GAS)
-(defun    (precompile-processing---dup-call-gas)      scenario/PRC_CALLEE_GAS)
+(defun    (precompile-processing---dup-callee-gas)    scenario/PRC_CALLEE_GAS)
 (defun    (precompile-processing---prd-return-gas)    scenario/PRC_RETURN_GAS)
 (defun    (precompile-processing---dup-cdo)           scenario/PRC_CDO)
 (defun    (precompile-processing---dup-cds)           scenario/PRC_CDS)

--- a/hub/prague/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
+++ b/hub/prague/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
@@ -38,7 +38,7 @@
 (defconstraint    precompile-processing---BLAKE2f---setting-the-second-OOB-instruction
                   (:guard    (precompile-processing---BLAKE2f---surviving-the-HUB))
                   (set-OOB-instruction---blake-params    precompile-processing---BLAKE2f---misc-row-offset---BLAKE-call-data-extraction    ;; offset
-                                                         (precompile-processing---dup-call-gas)                                            ;; call gas i.e. gas provided to the precompile
+                                                         (precompile-processing---dup-callee-gas)                                          ;; call gas i.e. gas provided to the precompile
                                                          (precompile-processing---BLAKE2f---r-parameter)                                   ;; rounds parameter of the call data of BLAKE2f
                                                          (precompile-processing---BLAKE2f---f-parameter)                                   ;; f      parameter of the call data of BLAKE2f ("final block indicator")
                                                          ))

--- a/hub/prague/constraints/instruction-handling/call/precompiles/common/generalities.lisp
+++ b/hub/prague/constraints/instruction-handling/call/precompiles/common/generalities.lisp
@@ -33,7 +33,7 @@
 (defconstraint    precompile-processing---common---setting-OOB-instruction    (:guard    (precompile-processing---common---precondition))
                   (set-OOB-instruction---common    precompile-processing---common---1st-misc-row---row-offset  ;; offset
                                                    (precompile-processing---common---OOB-instruction)          ;; relevant OOB instruction
-                                                   (precompile-processing---dup-call-gas)                      ;; call gas i.e. gas provided to the precompile
+                                                   (precompile-processing---dup-callee-gas)                    ;; call gas i.e. gas provided to the precompile
                                                    (precompile-processing---dup-cds)                           ;; call data size
                                                    (precompile-processing---dup-r@c)                           ;; return at capacity
                                                    )

--- a/hub/prague/constraints/instruction-handling/call/precompiles/modexp/common.lisp
+++ b/hub/prague/constraints/instruction-handling/call/precompiles/modexp/common.lisp
@@ -256,7 +256,7 @@
 
 (defconstraint    precompile-processing---MODEXP---pricing-analysis---setting-OOB-instruction    (:guard    (precompile-processing---MODEXP---standard-precondition))
                   (set-OOB-instruction---modexp-pricing    precompile-processing---MODEXP---misc-row-offset---pricing   ;; offset
-                                                           (precompile-processing---dup-call-gas)                       ;; call gas i.e. gas provided to the precompile
+                                                           (precompile-processing---dup-callee-gas)                     ;; call gas i.e. gas provided to the precompile
                                                            (precompile-processing---dup-r@c)                            ;; return at capacity
                                                            (precompile-processing---MODEXP---modexp-full-log)           ;; leading (≤) word log of exponent
                                                            (precompile-processing---MODEXP---max-mbs-bbs)               ;; call data size

--- a/hub/prague/constraints/instruction-handling/call/precompiles/shorthands.lisp
+++ b/hub/prague/constraints/instruction-handling/call/precompiles/shorthands.lisp
@@ -20,7 +20,7 @@
 
 
 (defun    (precompile-processing---dup-caller-gas)    scenario/PRC_CALLER_GAS)
-(defun    (precompile-processing---dup-call-gas)      scenario/PRC_CALLEE_GAS)
+(defun    (precompile-processing---dup-callee-gas)    scenario/PRC_CALLEE_GAS)
 (defun    (precompile-processing---prd-return-gas)    scenario/PRC_RETURN_GAS)
 (defun    (precompile-processing---dup-cdo)           scenario/PRC_CDO)
 (defun    (precompile-processing---dup-cds)           scenario/PRC_CDS)

--- a/hub/shanghai/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
+++ b/hub/shanghai/constraints/instruction-handling/call/precompiles/blake/surviving_the_hub.lisp
@@ -37,7 +37,7 @@
 (defconstraint    precompile-processing---BLAKE2f---setting-the-second-OOB-instruction
                   (:guard    (precompile-processing---BLAKE2f---surviving-the-HUB))
                   (set-OOB-instruction---blake-params    precompile-processing---BLAKE2f---misc-row-offset---BLAKE-call-data-extraction    ;; offset
-                                                         (precompile-processing---dup-call-gas)                                            ;; call gas i.e. gas provided to the precompile
+                                                         (precompile-processing---dup-callee-gas)                                          ;; call gas i.e. gas provided to the precompile
                                                          (precompile-processing---BLAKE2f---r-parameter)                                   ;; rounds parameter of the call data of BLAKE2f
                                                          (precompile-processing---BLAKE2f---f-parameter)                                   ;; f      parameter of the call data of BLAKE2f ("final block indicator")
                                                          ))

--- a/hub/shanghai/constraints/instruction-handling/call/precompiles/common/generalities.lisp
+++ b/hub/shanghai/constraints/instruction-handling/call/precompiles/common/generalities.lisp
@@ -32,7 +32,7 @@
 (defconstraint    precompile-processing---common---setting-OOB-instruction    (:guard    (precompile-processing---common---precondition))
                   (set-OOB-instruction---common    precompile-processing---common---1st-misc-row---row-offset  ;; offset
                                                    (precompile-processing---common---OOB-instruction)          ;; relevant OOB instruction
-                                                   (precompile-processing---dup-call-gas)                      ;; call gas i.e. gas provided to the precompile
+                                                   (precompile-processing---dup-callee-gas)                    ;; call gas i.e. gas provided to the precompile
                                                    (precompile-processing---dup-cds)                           ;; call data size
                                                    (precompile-processing---dup-r@c)                           ;; return at capacity
                                                    )

--- a/hub/shanghai/constraints/instruction-handling/call/precompiles/modexp/common.lisp
+++ b/hub/shanghai/constraints/instruction-handling/call/precompiles/modexp/common.lisp
@@ -256,7 +256,7 @@
 
 (defconstraint    precompile-processing---MODEXP---pricing-analysis---setting-OOB-instruction    (:guard    (precompile-processing---MODEXP---standard-precondition))
                   (set-OOB-instruction---modexp-pricing    precompile-processing---MODEXP---misc-row-offset---pricing   ;; offset
-                                                           (precompile-processing---dup-call-gas)                       ;; call gas i.e. gas provided to the precompile
+                                                           (precompile-processing---dup-callee-gas)                     ;; call gas i.e. gas provided to the precompile
                                                            (precompile-processing---dup-r@c)                            ;; return at capacity
                                                            (precompile-processing---MODEXP---modexp-full-log)           ;; leading (≤) word log of exponent
                                                            (precompile-processing---MODEXP---max-mbs-bbs)               ;; call data size

--- a/hub/shanghai/constraints/instruction-handling/call/precompiles/shorthands.lisp
+++ b/hub/shanghai/constraints/instruction-handling/call/precompiles/shorthands.lisp
@@ -20,7 +20,7 @@
 
 
 (defun    (precompile-processing---dup-caller-gas)    scenario/PRC_CALLER_GAS)
-(defun    (precompile-processing---dup-call-gas)      scenario/PRC_CALLEE_GAS)
+(defun    (precompile-processing---dup-callee-gas)    scenario/PRC_CALLEE_GAS)
 (defun    (precompile-processing---prd-return-gas)    scenario/PRC_RETURN_GAS)
 (defun    (precompile-processing---dup-cdo)           scenario/PRC_CDO)
 (defun    (precompile-processing---dup-cds)           scenario/PRC_CDS)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames `precompile-processing---dup-call-gas` to `precompile-processing---dup-callee-gas` and updates all usages across BLAKE2f, MODEXP, and common precompile logic in all hub versions.
> 
> - **Shorthands**:
>   - Rename `precompile-processing---dup-call-gas` to `precompile-processing---dup-callee-gas` in `hub/*/constraints/instruction-handling/call/precompiles/shorthands.lisp`.
> - **Usage updates**:
>   - Replace parameter `precompile-processing---dup-call-gas` with `precompile-processing---dup-callee-gas` in OOB instruction setters:
>     - `BLAKE2f`: `.../blake/surviving_the_hub.lisp`.
>     - `MODEXP` pricing: `.../modexp/common.lisp` and `.../modexp/common/__06__pricing_row.lisp` (Osaka).
>     - Common precompiles: `.../common/generalities.lisp` across hubs.
> - Affected hubs: `shanghai`, `london`, `cancun`, `prague`, `osaka`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c14b184494a2a92b73f2b10b54b63e0266a28cd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->