### PR TITLE
fixes readme liveliness & minor style tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the [Apache 2.0 license](LICENSE).
 
 [Linea](https://linea.build) is a developer-ready layer 2 network scaling Ethereum. It's secured with a zero-knowledge rollup, built on lattice-based cryptography, and powered by [Consensys](https://consensys.io).
 
-Linea is supported by the execution clients [Besu](https://github.com/hyperledger/besu/) or [Geth](https://github.com/ethereum/go-ethereum) which can leverage [Maru](https://github.com/Consensys/maru) to run a full node.
+Linea is compatible with the execution clients [Besu](https://github.com/hyperledger/besu/) or [Geth](https://github.com/ethereum/go-ethereum). To run a full node, an execution client is paired with [Maru](https://github.com/Consensys/maru).
 
 <!-- ## Get started
 


### PR DESCRIPTION
- Besu supports linea 
- Sequencer plugins now in monorepo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README to note Besu/Geth compatibility with Maru, consolidates plugin info under linea-monorepo, and makes minor copy/style tweaks.
> 
> - **Documentation (README)**:
>   - Clarify node compatibility: add support note for `Besu`/`Geth` and pairing with `Maru` for full nodes.
>   - Update repo list: consolidate sequencer/tracer/RPC plugin info under `linea-monorepo`; remove separate `linea-besu`/`linea-sequencer` bullets.
>   - Minor copy/style tweaks: fix heading capitalization for contribution guidelines; annotate `Linea docs` link as managed from a public repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1680deb86b708e874d671b87b52a75e1177f1d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->