### PR TITLE
feat: preliminary fixes for small fields

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@1aee6f95c28b1ca2f66f6d8347a0d247d8be38a4 # v1.2.0-rc3
+      run: go install github.com/consensys/go-corset/cmd/go-corset@adb969ee2eb4b09624498a1e954a3685f17e06e1 #v1.2.0-rc4
 
     - name: Build all forks
       run: make -B all

--- a/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__02__bbs_extraction_row.lisp
+++ b/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__02__bbs_extraction_row.lisp
@@ -22,7 +22,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;                                       ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
 (defconstraint    precompile-processing---MODEXP---bbs-extraction-and-analysis---setting-misc-module-flags
                   (:guard    (precompile-processing---MODEXP---standard-precondition))
                   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -68,7 +67,7 @@
                                                        ))
 
 
-(defun    (precompile-processing---MODEXP---bbs-within-bounds)    (shift    [misc/OOB_DATA   9]    precompile-processing---MODEXP---misc-row-offset---bbs-extraction-and-analysis)) ;; ""
-(defun    (precompile-processing---MODEXP---bbs-out-of-bounds)    (shift    [misc/OOB_DATA  10]    precompile-processing---MODEXP---misc-row-offset---bbs-extraction-and-analysis)) ;; ""
+(defun    (precompile-processing---MODEXP---bbs-within-bounds)    (i1 (shift    [misc/OOB_DATA   9]    precompile-processing---MODEXP---misc-row-offset---bbs-extraction-and-analysis)))
+(defun    (precompile-processing---MODEXP---bbs-out-of-bounds)    (i1 (shift    [misc/OOB_DATA  10]    precompile-processing---MODEXP---misc-row-offset---bbs-extraction-and-analysis)))
 (defun    (precompile-processing---MODEXP---bbs-normalized)       (*   (precompile-processing---MODEXP---bbs-lo)
                                                                        (precompile-processing---MODEXP---bbs-within-bounds)))

--- a/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__03__ebs_extraction_row.lisp
+++ b/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__03__ebs_extraction_row.lisp
@@ -69,7 +69,7 @@
                                                        ))
 
 
-(defun    (precompile-processing---MODEXP---ebs-within-bounds)    (shift    [misc/OOB_DATA   9]    precompile-processing---MODEXP---misc-row-offset---ebs-extraction-and-analysis))
-(defun    (precompile-processing---MODEXP---ebs-out-of-bounds)    (shift    [misc/OOB_DATA  10]    precompile-processing---MODEXP---misc-row-offset---ebs-extraction-and-analysis)) ;; ""
+(defun    (precompile-processing---MODEXP---ebs-within-bounds)    (i1 (shift    [misc/OOB_DATA   9]    precompile-processing---MODEXP---misc-row-offset---ebs-extraction-and-analysis)))
+(defun    (precompile-processing---MODEXP---ebs-out-of-bounds)    (i1 (shift    [misc/OOB_DATA  10]    precompile-processing---MODEXP---misc-row-offset---ebs-extraction-and-analysis))) ;; ""
 (defun    (precompile-processing---MODEXP---ebs-normalized)       (*   (precompile-processing---MODEXP---ebs-lo)
                                                                        (precompile-processing---MODEXP---ebs-within-bounds)))

--- a/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__04__mbs_extraction_row.lisp
+++ b/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__04__mbs_extraction_row.lisp
@@ -70,9 +70,9 @@
 
 
 (defun    (precompile-processing---MODEXP---max-mbs-bbs)          (shift    [misc/OOB_DATA   7]    precompile-processing---MODEXP---misc-row-offset---mbs-extraction-and-analysis)) ;; ""
-(defun    (precompile-processing---MODEXP---mbs-nonzero)          (shift    [misc/OOB_DATA   8]    precompile-processing---MODEXP---misc-row-offset---mbs-extraction-and-analysis)) ;; ""
-(defun    (precompile-processing---MODEXP---mbs-within-bounds)    (shift    [misc/OOB_DATA   9]    precompile-processing---MODEXP---misc-row-offset---mbs-extraction-and-analysis)) ;; ""
-(defun    (precompile-processing---MODEXP---mbs-out-of-bounds)    (shift    [misc/OOB_DATA  10]    precompile-processing---MODEXP---misc-row-offset---mbs-extraction-and-analysis)) ;; ""
+(defun    (precompile-processing---MODEXP---mbs-nonzero)          (i1 (shift    [misc/OOB_DATA   8]    precompile-processing---MODEXP---misc-row-offset---mbs-extraction-and-analysis))) ;; ""
+(defun    (precompile-processing---MODEXP---mbs-within-bounds)    (i1 (shift    [misc/OOB_DATA   9]    precompile-processing---MODEXP---misc-row-offset---mbs-extraction-and-analysis))) ;; ""
+(defun    (precompile-processing---MODEXP---mbs-out-of-bounds)    (i1 (shift    [misc/OOB_DATA  10]    precompile-processing---MODEXP---misc-row-offset---mbs-extraction-and-analysis))) ;; ""
 (defun    (precompile-processing---MODEXP---mbs-normalized)       (*   (precompile-processing---MODEXP---mbs-lo)
                                                                        (precompile-processing---MODEXP---mbs-within-bounds)))
 

--- a/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__06__pricing_row.lisp
+++ b/hub/osaka/constraints/instruction-handling/call/precompiles/modexp/common/__06__pricing_row.lisp
@@ -47,6 +47,6 @@
                                                                           (precompile-processing---MODEXP---max-mbs-bbs)               ;; call data size
                                                                           )))
 
-(defun    (precompile-processing---MODEXP---ram-success)    (shift    [misc/OOB_DATA   4]    precompile-processing---MODEXP---misc-row-offset---pricing))
+(defun    (precompile-processing---MODEXP---ram-success)    (i1 (shift    [misc/OOB_DATA   4]    precompile-processing---MODEXP---misc-row-offset---pricing)))
 (defun    (precompile-processing---MODEXP---return-gas)     (shift    [misc/OOB_DATA   5]    precompile-processing---MODEXP---misc-row-offset---pricing))
-(defun    (precompile-processing---MODEXP---r@c-nonzero)    (shift    [misc/OOB_DATA   8]    precompile-processing---MODEXP---misc-row-offset---pricing)) ;; ""
+(defun    (precompile-processing---MODEXP---r@c-nonzero)    (i1 (shift    [misc/OOB_DATA   8]    precompile-processing---MODEXP---misc-row-offset---pricing)))

--- a/mxp/computations/not_msize.lisp
+++ b/mxp/computations/not_msize.lisp
@@ -15,10 +15,10 @@
 				      (mxp-shorthand---size-2-lo)
 				      ))
 
-(defun   (mxp-shorthand---size-1-is-zero)      (shift computation/RES_A ROW_OFFSET___1ST_SIZE___ZERONESS_TEST))
-(defun   (mxp-shorthand---size-2-is-zero)      (shift computation/RES_A ROW_OFFSET___2ND_SIZE___ZERONESS_TEST))
-(defun   (mxp-shorthand---size-1-is-nonzero)   (-  1  (mxp-shorthand---size-1-is-zero)))
-(defun   (mxp-shorthand---size-2-is-nonzero)   (-  1  (mxp-shorthand---size-2-is-zero)))
+(defun   ((mxp-shorthand---size-1-is-zero :binary :force))      (shift computation/RES_A ROW_OFFSET___1ST_SIZE___ZERONESS_TEST))
+(defun   ((mxp-shorthand---size-2-is-zero :binary :force))      (shift computation/RES_A ROW_OFFSET___2ND_SIZE___ZERONESS_TEST))
+(defun   ((mxp-shorthand---size-1-is-nonzero :binary))   (-  1  (mxp-shorthand---size-1-is-zero)))
+(defun   ((mxp-shorthand---size-2-is-nonzero :binary))   (-  1  (mxp-shorthand---size-2-is-zero)))
 
 (defconstraint  computations---not-msize---setting-the-TRIVIAL-scenario-flag
 		(:guard   (mxp-guard---not-msize))

--- a/mxp/computations/state_update.lisp
+++ b/mxp/computations/state_update.lisp
@@ -16,8 +16,8 @@
 				 (*  (mxp-shorthand---double-offset-instruction)  (mxp-shorthand---max-2))
 				 ))
 
-(defun  (mxp-shorthand---use-parameter-set-2)  (shift  computation/RES_A  ROW_OFFSET___COMPARISON_OF_MAX_OFFSETS))
-(defun  (mxp-shorthand---use-parameter-set-1)  (-   1    (mxp-shorthand---use-parameter-set-2)))
+(defun  ((mxp-shorthand---use-parameter-set-2 :binary :force))  (shift  computation/RES_A  ROW_OFFSET___COMPARISON_OF_MAX_OFFSETS))
+(defun  ((mxp-shorthand---use-parameter-set-1 :binary))  (-   1    (mxp-shorthand---use-parameter-set-2)))
 
 (defun  (mxp-shorthand---max-1)          (* (mxp-shorthand---size-1-is-nonzero) (+ (mxp-shorthand---offset-1-lo)   (mxp-shorthand---size-1-lo))))
 (defun  (mxp-shorthand---max-2)          (* (mxp-shorthand---size-2-is-nonzero) (+ (mxp-shorthand---offset-2-lo)   (mxp-shorthand---size-2-lo))))

--- a/romlex/constraints.lisp
+++ b/romlex/constraints.lisp
@@ -20,5 +20,5 @@
   (begin (eq! CODE_HASH_HI EMPTY_KECCAK_HI)
          (eq! CODE_HASH_LO EMPTY_KECCAK_LO)))
 
-(defstrictsorted cfi-strict-lexicographic-order (prev CFI)
+(defstrictsorted cfi-strict-lexicographic-order (prev (~ CFI))
                  ((+ ADDRESS_HI) (+ ADDRESS_LO) (+ DEPLOYMENT_NUMBER) (- DEPLOYMENT_STATUS)))


### PR DESCRIPTION

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Constraints tightening (MODEXP/MXP):** Wrap OOB/flag reads with `i1` and add `:binary`/`:force` annotations for `bbs/ebs/mbs` bounds and pricing flags, plus `mxp` `size-*` and `use-parameter-set-*` helpers to ensure boolean semantics.
> - **ROMLEX:** Change `defstrictsorted cfi-strict-lexicographic-order` to use `(prev (~ CFI))`.
> - **CI:** Update Go Corset install to `github.com/consensys/go-corset/...@adb969e...` (# v1.2.0-rc4).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08d8a2bff32da66c8b3312068ae0ac3d696b3063. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->