### PR TITLE
perf: cast intermediate result

### DIFF
--- a/mmio/instructions.lisp
+++ b/mmio/instructions.lisp
@@ -100,6 +100,7 @@
                                             [BIT 3]
                                             CT)))
 
+
 (defconstraint ram-to-limb-two-source (:guard IS_RAM_TO_LIMB_TWO_SOURCE)
                (begin (eq! CN_A CNS)
                       (eq! CN_B CNS)
@@ -187,6 +188,10 @@
                                              [BIT 5]
                                              CT)))
 
+;; This is just a way to cast an intermediate result, as the current constraint were creating a i354 which makes the splitting huge.
+
+(defcomputed (CAST_INTERMEDIATE_RESULT :i128 :fwd) (* IS_RAM_TO_LIMB_TWO_SOURCE [ACC 1] [POW_256 2]))
+
 (defconstraint ram-to-ram-two-source (:guard IS_RAM_TO_RAM_TWO_SOURCE)
                (begin (eq! CN_A CNS)
                       (eq! CN_B CNS)
@@ -213,7 +218,38 @@
                                              [BIT 2]
                                              [BIT 3]
                                              [BIT 4]
-                                             CT)))
+                                             CT
+                                             CAST_INTERMEDIATE_RESULT)))
+
+;; original constraint:                                                      
+;; 
+;; (defconstraint ram-to-ram-two-source (:guard IS_RAM_TO_RAM_TWO_SOURCE)
+;;                (begin (eq! CN_A CNS)
+;;                       (eq! CN_B CNS)
+;;                       (eq! CN_C CNT)
+;;                       (eq! INDEX_A SLO)
+;;                       (eq! INDEX_B (+ SLO 1))
+;;                       (eq! INDEX_C TLO)
+;;                       (eq! VAL_A_NEW VAL_A)
+;;                       (eq! VAL_B_NEW VAL_B)
+;;                       (two-partial-to-one    VAL_C
+;;                                              VAL_C_NEW
+;;                                              BYTE_A
+;;                                              BYTE_B
+;;                                              BYTE_C
+;;                                              [ACC 1]
+;;                                              [ACC 2]
+;;                                              [ACC 3]
+;;                                              [POW_256 1]
+;;                                              [POW_256 2]
+;;                                              SBO
+;;                                              TBO
+;;                                              SIZE
+;;                                              [BIT 1]
+;;                                              [BIT 2]
+;;                                              [BIT 3]
+;;                                              [BIT 4]
+;;                                              CT)))
 
 (defconstraint ram-excision (:guard IS_RAM_EXCISION)
                (begin (eq! CN_A CNT)

--- a/mmio/instructions.lisp
+++ b/mmio/instructions.lisp
@@ -190,7 +190,7 @@
 
 ;; This is just a way to cast an intermediate result, as the current constraint were creating a i354 which makes the splitting huge.
 
-(defcomputedcolumn (CAST_INTERMEDIATE_RESULT :i128 :fwd) (* IS_RAM_TO_LIMB_TWO_SOURCE [ACC 1] [POW_256 2]))
+(defcomputedcolumn (CAST_INTERMEDIATE_RESULT :i128 :fwd) (* IS_RAM_TO_RAM_TWO_SOURCE [ACC 1] [POW_256 2]))
 
 (defconstraint ram-to-ram-two-source (:guard IS_RAM_TO_RAM_TWO_SOURCE)
                (begin (eq! CN_A CNS)

--- a/mmio/instructions.lisp
+++ b/mmio/instructions.lisp
@@ -190,7 +190,7 @@
 
 ;; This is just a way to cast an intermediate result, as the current constraint were creating a i354 which makes the splitting huge.
 
-(defcomputed (CAST_INTERMEDIATE_RESULT :i128 :fwd) (* IS_RAM_TO_LIMB_TWO_SOURCE [ACC 1] [POW_256 2]))
+(defcomputedcolumn (CAST_INTERMEDIATE_RESULT :i128 :fwd) (* IS_RAM_TO_LIMB_TWO_SOURCE [ACC 1] [POW_256 2]))
 
 (defconstraint ram-to-ram-two-source (:guard IS_RAM_TO_RAM_TWO_SOURCE)
                (begin (eq! CN_A CNS)

--- a/mmio/patterns.lisp
+++ b/mmio/patterns.lisp
@@ -150,6 +150,9 @@
                                          (* (- accumulator4 accumulator2) pow)))))))
 
 ;; [2 Partial => 1]
+
+;; This is just a way to cast an intermediate result, as the current constraint were creating a i354 which makes the splitting huge.
+
 (defpurefun (two-partial-to-one target
                                 target_new
                                 source1_byte
@@ -167,7 +170,8 @@
                                 bit2
                                 bit3
                                 bit4
-                                counter)
+                                counter
+                                cast_interemediate_result)
             (begin (plateau bit1 source_marker counter)
                    (plateau bit2
                             (- (+ source_marker size) LLARGE)
@@ -182,6 +186,43 @@
                    (if-eq counter LLARGEMO
                             (eq! target_new
                                  (+ target
-                                    (* (- (+ (* accumulator1 pow2) accumulator2)
+                                    (* (- (+ cast_interemediate_result accumulator2)
                                           accumulator3)
                                        pow1))))))
+
+;; original constraint:
+;; (defpurefun (two-partial-to-one target
+;;                                 target_new
+;;                                 source1_byte
+;;                                 source2_byte
+;;                                 target_byte
+;;                                 accumulator1
+;;                                 accumulator2
+;;                                 accumulator3
+;;                                 pow1
+;;                                 pow2
+;;                                 source_marker
+;;                                 target_marker
+;;                                 size
+;;                                 bit1
+;;                                 bit2
+;;                                 bit3
+;;                                 bit4
+;;                                 counter)
+;;             (begin (plateau bit1 source_marker counter)
+;;                    (plateau bit2
+;;                             (- (+ source_marker size) LLARGE)
+;;                             counter)
+;;                    (plateau bit3 target_marker counter)
+;;                    (plateau bit4 (+ target_marker size) counter)
+;;                    (isolate-suffix accumulator1 source1_byte bit1 counter)
+;;                    (isolate-prefix accumulator2 source2_byte bit2 counter)
+;;                    (isolate-chunk accumulator3 target_byte bit3 bit4 counter)
+;;                    (power pow1 bit4 counter)
+;;                    (antipower pow2 bit2 counter)
+;;                    (if-eq counter LLARGEMO
+;;                             (eq! target_new
+;;                                  (+ target
+;;                                     (* (- (+ (* accumulator1 pow2) accumulator2)
+;;                                           accumulator3)
+;;                                        pow1))))))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Optimizes RAM-to-RAM two-source constraint by capping intermediate width.
> 
> - Adds `CAST_INTERMEDIATE_RESULT` computed column (`:i128`) for `IS_RAM_TO_RAM_TWO_SOURCE` as `[ACC 1] * [POW_256 2]`
> - Extends `two-partial-to-one` with `cast_interemediate_result` param and replaces `(* accumulator1 pow2)` with the casted value
> - Updates `ram-to-ram-two-source` to pass `CAST_INTERMEDIATE_RESULT` to `two-partial-to-one`
> - Includes inline comments documenting the change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31bc553f0e835ee583dd66b4f17119f2e1423a6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->