### PR TITLE
GH Actions Security improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+updates:
+  # 1) GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /            # GitHub scans .github/workflows from here
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+    open-pull-requests-limit: 5
+    assignees: ["OlivierBBB", "letypequividelespoubelles"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "deps(actions)"
+      include: "scope"
+    groups:
+      core-actions-minor-patch:
+        update-types: ["minor", "patch"]
+        patterns:
+          - "actions/*"
+          - "github/*"
+      third-party-actions-minor-patch:
+        update-types: ["minor", "patch"]
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"
+          - "github/*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,9 +2,13 @@ name: Check compilation
 
 on: [push, pull_request]
 
+permissions: {} # lock everything by default (least-privilege)
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,21 +1,25 @@
 name: Check compilation
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 permissions: {} # lock everything by default (least-privilege)
 
 jobs:
   build:
+    name: Compile constraint system
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Install Go
-      uses: actions/setup-go@v5.1.0
+      uses: actions/setup-go@v6
 
     - name: Install Go Corset
       shell: bash

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -15,6 +15,8 @@ on:
         required: false
   workflow_dispatch:
 
+permissions: {} # lock everything by default (least-privilege)
+
 jobs:
   security-scan:
     uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2


### PR DESCRIPTION
GH Actions Security improvements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes (workflow permissions, triggers, and action version bumps) with minimal impact beyond potentially changing when workflows run or exposing incompatibilities in updated actions.
> 
> **Overview**
> Hardens GitHub Actions by setting default workflow `permissions: {}` and granting only required job-level scopes (e.g., `contents: read` for the build, `security-events: write` for code scanning).
> 
> Updates the compilation workflow triggers to run `push` only on `master` and bumps `actions/checkout` and `actions/setup-go` to `v6`.
> 
> Adds `.github/dependabot.yml` to enable weekly GitHub Actions dependency updates with grouped minor/patch PRs, labeling/assignees, and a 7-day cooldown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 885d07450290a6931491bd709b94dfe3f364fc90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->